### PR TITLE
feat: implement TAS playback infrastructure and FM2 parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,6 +3072,7 @@ dependencies = [
  "ndk-context",
  "nesium-core",
  "nesium-runtime",
+ "nesium-support",
 ]
 
 [[package]]
@@ -3142,8 +3143,11 @@ dependencies = [
 name = "nesium-support"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.10.0",
+ "hex",
  "lz4_flex",
  "nesium-core",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/apps/nesium_flutter/lib/bridge/api/emulation.dart
+++ b/apps/nesium_flutter/lib/bridge/api/emulation.dart
@@ -31,3 +31,6 @@ Future<void> setRewindConfig({
 
 Future<void> setRewinding({required bool rewinding}) =>
     RustLib.instance.api.crateApiEmulationSetRewinding(rewinding: rewinding);
+
+Future<void> loadTasMovie({required String data}) =>
+    RustLib.instance.api.crateApiEmulationLoadTasMovie(data: data);

--- a/apps/nesium_flutter/lib/bridge/frb_generated.dart
+++ b/apps/nesium_flutter/lib/bridge/frb_generated.dart
@@ -72,7 +72,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1460160878;
+  int get rustContentHash => 2102738803;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -98,6 +98,8 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiEmulationLoadState({required String path});
 
   Future<void> crateApiEmulationLoadStateFromMemory({required List<int> data});
+
+  Future<void> crateApiEmulationLoadTasMovie({required String data});
 
   Future<List<PalettePresetInfo>> crateApiPalettePalettePresets();
 
@@ -369,6 +371,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiEmulationLoadTasMovie({required String data}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(data, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 9,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiEmulationLoadTasMovieConstMeta,
+        argValues: [data],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEmulationLoadTasMovieConstMeta =>
+      const TaskConstMeta(debugName: "load_tas_movie", argNames: ["data"]);
+
+  @override
   Future<List<PalettePresetInfo>> crateApiPalettePalettePresets() {
     return handler.executeNormal(
       NormalTask(
@@ -377,7 +407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -404,7 +434,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -431,7 +461,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 12,
             port: port_,
           );
         },
@@ -461,7 +491,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 12,
+              funcId: 13,
               port: port_,
             );
           },
@@ -494,7 +524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -521,7 +551,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -549,7 +579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -581,7 +611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -609,7 +639,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -640,7 +670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -668,7 +698,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -700,7 +730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -731,7 +761,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -759,7 +789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -794,7 +824,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -828,7 +858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -858,7 +888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -885,7 +915,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },

--- a/apps/nesium_flutter/lib/l10n/app_en.arb
+++ b/apps/nesium_flutter/lib/l10n/app_en.arb
@@ -128,6 +128,7 @@
   "menuSaveState": "Save State...",
   "menuLoadState": "Load State...",
   "menuPauseResume": "Pause / Resume",
+  "menuLoadTasMovie": "Load TAS Movie...",
   "menuPreferences": "Preferences...",
   "saveToExternalFile": "Save to file...",
   "loadFromExternalFile": "Load from file...",

--- a/apps/nesium_flutter/lib/l10n/app_localizations.dart
+++ b/apps/nesium_flutter/lib/l10n/app_localizations.dart
@@ -602,6 +602,12 @@ abstract class AppLocalizations {
   /// **'Pause / Resume'**
   String get menuPauseResume;
 
+  /// No description provided for @menuLoadTasMovie.
+  ///
+  /// In en, this message translates to:
+  /// **'Load TAS Movie...'**
+  String get menuLoadTasMovie;
+
   /// No description provided for @menuPreferences.
   ///
   /// In en, this message translates to:

--- a/apps/nesium_flutter/lib/l10n/app_localizations_en.dart
+++ b/apps/nesium_flutter/lib/l10n/app_localizations_en.dart
@@ -282,6 +282,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get menuPauseResume => 'Pause / Resume';
 
   @override
+  String get menuLoadTasMovie => 'Load TAS Movie...';
+
+  @override
   String get menuPreferences => 'Preferences...';
 
   @override

--- a/apps/nesium_flutter/lib/l10n/app_localizations_zh.dart
+++ b/apps/nesium_flutter/lib/l10n/app_localizations_zh.dart
@@ -274,6 +274,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get menuPauseResume => '暂停 / 继续';
 
   @override
+  String get menuLoadTasMovie => '加载 TAS 录像…';
+
+  @override
   String get menuPreferences => '偏好设置…';
 
   @override

--- a/apps/nesium_flutter/lib/l10n/app_zh.arb
+++ b/apps/nesium_flutter/lib/l10n/app_zh.arb
@@ -99,6 +99,7 @@
   "menuSaveState": "保存存档…",
   "menuLoadState": "读取存档…",
   "menuPauseResume": "暂停 / 继续",
+  "menuLoadTasMovie": "加载 TAS 录像…",
   "menuPreferences": "偏好设置…",
   "saveToExternalFile": "保存到外部文件…",
   "loadFromExternalFile": "从外部文件加载…",

--- a/apps/nesium_flutter/lib/platform/nes_emulation_io.dart
+++ b/apps/nesium_flutter/lib/platform/nes_emulation_io.dart
@@ -10,3 +10,6 @@ Future<void> setRewindConfig({
 
 Future<void> setRewinding({required bool rewinding}) =>
     frb_emulation.setRewinding(rewinding: rewinding);
+
+Future<void> loadTasMovie({required String data}) =>
+    frb_emulation.loadTasMovie(data: data);

--- a/apps/nesium_flutter/lib/platform/nes_emulation_web.dart
+++ b/apps/nesium_flutter/lib/platform/nes_emulation_web.dart
@@ -34,3 +34,8 @@ Future<Uint8List> saveStateToMemory() async {
 Future<void> loadStateFromMemory({required Uint8List data}) async {
   return webRequest<void>('loadState', {'data': data});
 }
+
+Future<void> loadTasMovie({required String data}) async {
+  if (!isWebNesReady) return;
+  webPostCmd('loadTasMovie', {'data': data});
+}

--- a/apps/nesium_flutter/lib/shell/mobile_shell.dart
+++ b/apps/nesium_flutter/lib/shell/mobile_shell.dart
@@ -229,6 +229,8 @@ class _MobileDrawer extends StatelessWidget {
         item.id == NesMenuItemId.loadState ||
         item.id == NesMenuItemId.autoSave) {
       enabled = hasRom;
+    } else if (item.id == NesMenuItemId.loadTasMovie) {
+      enabled = false;
     }
 
     return ListTile(
@@ -252,7 +254,6 @@ class _MobileDrawer extends StatelessWidget {
     required VoidCallback closeDrawer,
     required Future<void> Function(Widget page) openPage,
   }) {
-    final l10n = AppLocalizations.of(context)!;
     switch (id) {
       case NesMenuItemId.openRom:
         closeDrawer();
@@ -286,14 +287,12 @@ class _MobileDrawer extends StatelessWidget {
         closeDrawer();
         unawaited(actions.togglePause());
         break;
-      case NesMenuItemId.settings:
+      case NesMenuItemId.loadTasMovie:
         closeDrawer();
-        unawaited(actions.openSettings());
-        break;
-      case NesMenuItemId.about:
-        unawaited(openPage(const AboutPage()));
+        unawaited(actions.loadTasMovie?.call());
         break;
       case NesMenuItemId.debugger:
+        final l10n = AppLocalizations.of(context)!;
         unawaited(
           openPage(
             _MobilePage(
@@ -304,6 +303,7 @@ class _MobileDrawer extends StatelessWidget {
         );
         break;
       case NesMenuItemId.tools:
+        final l10n = AppLocalizations.of(context)!;
         unawaited(
           openPage(
             _MobilePage(
@@ -313,12 +313,19 @@ class _MobileDrawer extends StatelessWidget {
           ),
         );
         break;
+      case NesMenuItemId.settings:
+        closeDrawer();
+        unawaited(actions.openSettings());
+        break;
+      case NesMenuItemId.about:
+        unawaited(openPage(const AboutPage()));
+        break;
       case NesMenuItemId.autoSaveSlot:
       case NesMenuItemId.saveStateSlot:
       case NesMenuItemId.loadStateSlot:
       case NesMenuItemId.saveStateFile:
       case NesMenuItemId.loadStateFile:
-        // Desktop submenus, not used in mobile drawer currently
+        // Desktop submenus, not used in mobile drawer currently.
         break;
     }
   }

--- a/apps/nesium_flutter/lib/shell/nes_actions.dart
+++ b/apps/nesium_flutter/lib/shell/nes_actions.dart
@@ -12,6 +12,7 @@ class NesActions {
     this.loadStateSlot,
     this.saveStateFile,
     this.loadStateFile,
+    this.loadTasMovie,
     required this.reset,
     required this.powerReset,
     required this.eject,
@@ -30,6 +31,7 @@ class NesActions {
   final NesSlotCallback? loadStateSlot;
   final AsyncCallback? saveStateFile;
   final AsyncCallback? loadStateFile;
+  final AsyncCallback? loadTasMovie;
   final AsyncCallback reset;
   final AsyncCallback powerReset;
   final AsyncCallback eject;

--- a/apps/nesium_flutter/lib/shell/nes_menu_bar.dart
+++ b/apps/nesium_flutter/lib/shell/nes_menu_bar.dart
@@ -113,6 +113,8 @@ class NesMenuBar extends StatelessWidget {
       if (!hasRom) {
         enabled = false;
       }
+    } else if (item.id == NesMenuItemId.loadTasMovie) {
+      enabled = false;
     }
 
     return MenuItemButton(
@@ -163,6 +165,9 @@ class NesMenuBar extends StatelessWidget {
         break;
       case NesMenuItemId.togglePause:
         unawaited(actions.togglePause());
+        break;
+      case NesMenuItemId.loadTasMovie:
+        unawaited(actions.loadTasMovie?.call());
         break;
       case NesMenuItemId.settings:
         unawaited(actions.openSettings());

--- a/apps/nesium_flutter/lib/shell/nes_menu_model.dart
+++ b/apps/nesium_flutter/lib/shell/nes_menu_model.dart
@@ -16,6 +16,7 @@ enum NesMenuItemId {
   powerReset,
   eject,
   togglePause,
+  loadTasMovie,
   settings,
   about,
   debugger,
@@ -65,6 +66,7 @@ class NesMenuItemSpec {
       NesMenuItemId.powerReset => l10n.menuPowerReset,
       NesMenuItemId.eject => l10n.menuEject,
       NesMenuItemId.togglePause => l10n.menuPauseResume,
+      NesMenuItemId.loadTasMovie => l10n.menuLoadTasMovie,
       NesMenuItemId.settings => l10n.menuPreferences,
       NesMenuItemId.about => l10n.menuAbout,
       NesMenuItemId.debugger => l10n.menuDebugger,
@@ -118,6 +120,10 @@ class NesMenus {
   static const NesMenuItemSpec togglePause = NesMenuItemSpec(
     id: NesMenuItemId.togglePause,
     icon: Icons.pause_circle_outline,
+  );
+  static const NesMenuItemSpec loadTasMovie = NesMenuItemSpec(
+    id: NesMenuItemId.loadTasMovie,
+    icon: Icons.movie_outlined,
   );
   static const NesMenuItemSpec settings = NesMenuItemSpec(
     id: NesMenuItemId.settings,
@@ -205,7 +211,7 @@ class NesMenus {
     ),
     const NesMenuSectionSpec(
       id: NesMenuSectionId.emulation,
-      items: [togglePause, reset, powerReset, eject],
+      items: [togglePause, loadTasMovie, reset, powerReset, eject],
     ),
     const NesMenuSectionSpec(id: NesMenuSectionId.settings, items: [settings]),
     const NesMenuSectionSpec(
@@ -240,7 +246,7 @@ class NesMenus {
     ),
     const NesMenuSectionSpec(
       id: NesMenuSectionId.emulation,
-      items: [togglePause, reset, powerReset],
+      items: [togglePause, loadTasMovie, reset, powerReset],
     ),
     const NesMenuSectionSpec(id: NesMenuSectionId.settings, items: [settings]),
     const NesMenuSectionSpec(id: NesMenuSectionId.help, items: [about]),

--- a/apps/nesium_flutter/lib/shell/nes_shell.dart
+++ b/apps/nesium_flutter/lib/shell/nes_shell.dart
@@ -354,6 +354,27 @@ class _NesShellState extends ConsumerState<NesShell>
     }
   }
 
+  Future<void> _loadTasMovie() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['fm2'],
+      withData: true,
+      withReadStream: false,
+    );
+    final file = result?.files.single;
+    if (file == null) return;
+
+    final bytes = file.bytes;
+    if (bytes == null) return;
+
+    final data = String.fromCharCodes(bytes);
+
+    if (!mounted) return;
+    await _runRustCommand('Load TAS Movie', () async {
+      await nes_emulation.loadTasMovie(data: data);
+    });
+  }
+
   KeyEventResult _handleKeyEvent(FocusNode _, KeyEvent event) {
     // Avoid sending key events to the emulator when a different route (e.g. settings)
     // is on top.
@@ -481,6 +502,7 @@ class _NesShellState extends ConsumerState<NesShell>
       loadStateSlot: _loadFromSlot,
       saveStateFile: _saveToFile,
       loadStateFile: _loadFromFile,
+      loadTasMovie: _loadTasMovie,
       reset: _resetConsole,
       powerReset: _powerResetConsole,
       eject: _ejectConsole,

--- a/apps/nesium_flutter/web/nes/nes_worker.js
+++ b/apps/nesium_flutter/web/nes/nes_worker.js
@@ -311,6 +311,17 @@ onmessage = async (ev) => {
                     break;
                 }
 
+                case "loadTasMovie": {
+                    if (typeof nes.load_tas_movie !== "function") {
+                        throw new Error("Missing wasm export: load_tas_movie. Rebuild `web/nes/pkg`.");
+                    }
+                    nes.load_tas_movie(msg.data);
+                    // Match native behavior: reset pacing and wake loop
+                    nextFrameAt = 0;
+                    if (!timer) tick();
+                    break;
+                }
+
                 case "setRewindConfig": {
                     const enabled = !!msg.enabled;
                     const capacity = Number(msg.capacity);

--- a/crates/nesium-flutter/Cargo.toml
+++ b/crates/nesium-flutter/Cargo.toml
@@ -16,6 +16,7 @@ nesium-core.workspace = true
 flutter_rust_bridge.workspace = true
 anyhow.workspace = true
 nesium-runtime.workspace = true
+nesium-support.workspace = true
 
 [target.'cfg(any(target_os = "android", target_os = "windows", target_os = "linux"))'.dependencies]
 mimalloc = { workspace = true, optional = true }

--- a/crates/nesium-flutter/src/api/emulation.rs
+++ b/crates/nesium-flutter/src/api/emulation.rs
@@ -48,3 +48,11 @@ pub fn set_rewinding(rewinding: bool) -> Result<(), String> {
         .set_rewinding(rewinding)
         .map_err(|e| e.to_string())
 }
+
+#[frb]
+pub fn load_tas_movie(data: String) -> Result<(), String> {
+    let movie = nesium_support::tas::fm2::parse_str(&data).map_err(|e| e.to_string())?;
+    crate::runtime_handle()
+        .load_movie(movie)
+        .map_err(|e| e.to_string())
+}

--- a/crates/nesium-flutter/src/frb_generated.rs
+++ b/crates/nesium-flutter/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1460160878;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2102738803;
 
 // Section: executor
 
@@ -304,6 +304,39 @@ fn wire__crate__api__emulation__load_state_from_memory_impl(
                     })()
                     .await,
                 )
+            }
+        },
+    )
+}
+fn wire__crate__api__emulation__load_tas_movie_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "load_tas_movie",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_data = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::emulation::load_tas_movie(api_data)?;
+                    Ok(output_ok)
+                })())
             }
         },
     )
@@ -1097,47 +1130,48 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__api__palette__palette_presets_impl(port, ptr, rust_vec_len, data_len),
-        10 => {
+        9 => wire__crate__api__emulation__load_tas_movie_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__palette__palette_presets_impl(port, ptr, rust_vec_len, data_len),
+        11 => {
             wire__crate__api__load_rom__power_reset_console_impl(port, ptr, rust_vec_len, data_len)
         }
-        11 => wire__crate__api__load_rom__reset_console_impl(port, ptr, rust_vec_len, data_len),
-        12 => {
+        12 => wire__crate__api__load_rom__reset_console_impl(port, ptr, rust_vec_len, data_len),
+        13 => {
             wire__crate__api__events__runtime_notifications_impl(port, ptr, rust_vec_len, data_len)
         }
-        13 => wire__crate__api__emulation__save_state_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__emulation__save_state_to_memory_impl(
+        14 => wire__crate__api__emulation__save_state_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__emulation__save_state_to_memory_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__api__emulation__set_integer_fps_mode_impl(
+        16 => wire__crate__api__emulation__set_integer_fps_mode_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        16 => wire__crate__api__input__set_pad_mask_impl(port, ptr, rust_vec_len, data_len),
-        17 => {
+        17 => wire__crate__api__input__set_pad_mask_impl(port, ptr, rust_vec_len, data_len),
+        18 => {
             wire__crate__api__palette__set_palette_pal_data_impl(port, ptr, rust_vec_len, data_len)
         }
-        18 => wire__crate__api__palette__set_palette_preset_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__pause__set_paused_impl(port, ptr, rust_vec_len, data_len),
-        20 => {
+        19 => wire__crate__api__palette__set_palette_preset_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__pause__set_paused_impl(port, ptr, rust_vec_len, data_len),
+        21 => {
             wire__crate__api__emulation__set_rewind_config_impl(port, ptr, rust_vec_len, data_len)
         }
-        21 => wire__crate__api__emulation__set_rewinding_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__input__set_turbo_frames_per_toggle_impl(
+        22 => wire__crate__api__emulation__set_rewinding_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__input__set_turbo_frames_per_toggle_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__input__set_turbo_mask_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__input__set_turbo_timing_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__load_rom__start_nes_runtime_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__pause__toggle_pause_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__input__set_turbo_mask_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__input__set_turbo_timing_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__load_rom__start_nes_runtime_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__pause__toggle_pause_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/crates/nesium-runtime/src/runtime/control.rs
+++ b/crates/nesium-runtime/src/runtime/control.rs
@@ -29,6 +29,7 @@ pub(crate) enum ControlMessage {
     SaveStateToMemory(Sender<Result<Vec<u8>, RuntimeError>>),
     LoadStateFromMemory(Vec<u8>, ControlReplySender),
     SetRewinding(bool, ControlReplySender),
+    LoadMovie(nesium_support::tas::Movie, ControlReplySender),
 }
 
 // SAFETY: raw pointers and function pointers are forwarded to the runtime thread without

--- a/crates/nesium-runtime/src/runtime/handle.rs
+++ b/crates/nesium-runtime/src/runtime/handle.rs
@@ -392,4 +392,10 @@ impl RuntimeHandle {
             ControlMessage::SetRewinding(rewinding, reply)
         })
     }
+
+    pub fn load_movie(&self, movie: nesium_support::tas::Movie) -> Result<(), RuntimeError> {
+        self.send_with_reply("load_movie", CONTROL_REPLY_TIMEOUT, |reply| {
+            ControlMessage::LoadMovie(movie, reply)
+        })
+    }
 }

--- a/crates/nesium-support/Cargo.toml
+++ b/crates/nesium-support/Cargo.toml
@@ -5,5 +5,8 @@ edition = "2024"
 license.workspace = true
 
 [dependencies]
-nesium-core.workspace = true
+nesium-core = { workspace = true, features = ["savestate-postcard"] }
 lz4_flex.workspace = true
+bitflags.workspace = true
+thiserror.workspace = true
+hex = "0.4.3"

--- a/crates/nesium-support/src/error.rs
+++ b/crates/nesium-support/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SupportError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Invalid TAS movie data: {0}")]
+    InvalidTasData(String),
+
+    #[error("Unsupported TAS movie format: {0}")]
+    UnsupportedTasFormat(String),
+}

--- a/crates/nesium-support/src/lib.rs
+++ b/crates/nesium-support/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod error;
 pub mod rewind;
+pub mod tas;

--- a/crates/nesium-support/src/rewind.rs
+++ b/crates/nesium-support/src/rewind.rs
@@ -198,7 +198,7 @@ impl RewindState {
     ///
     /// This performs an LZ4 decompression and a byte-wise XOR. On any decoding
     /// error, the rewind history is cleared and `None` is returned.
-    pub fn rewind_one_frame(&mut self) -> Option<(NesSnapshot, Vec<u8>)> {
+    pub fn rewind_frame(&mut self) -> Option<(NesSnapshot, Vec<u8>)> {
         if !self.can_rewind() {
             return None;
         }

--- a/crates/nesium-support/src/tas/fm2.rs
+++ b/crates/nesium-support/src/tas/fm2.rs
@@ -1,0 +1,228 @@
+use crate::error::SupportError;
+use crate::tas::{FrameFlags, InputFrame, Movie, TasData};
+use std::io::{BufRead, Cursor};
+
+/// FM2-specific header metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Fm2Header {
+    pub version: u32,
+    pub emu_version: String,
+    pub rerecord_count: u32,
+    pub pal_flag: bool,
+    pub rom_filename: String,
+    pub guid: String,
+    pub fourscore: bool,
+    pub microphone: bool,
+    pub ports: [u8; 3],
+    pub fds: bool,
+    pub ppu_flag: bool,
+    pub ram_init_option: u32,
+    pub ram_init_seed: u32,
+    pub comments: Vec<String>,
+    pub subtitles: Vec<String>,
+    pub binary_flag: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ParseState {
+    Newline,
+    Key,
+    Separator,
+    Value,
+}
+
+pub fn parse<R: BufRead>(mut reader: R) -> Result<Movie, SupportError> {
+    let mut version_buf = [0u8; 9];
+    reader
+        .read_exact(&mut version_buf)
+        .map_err(SupportError::Io)?;
+    if &version_buf != b"version 3" {
+        return Err(SupportError::InvalidTasData(
+            "Invalid FM2 version header".to_string(),
+        ));
+    }
+
+    let mut header = Fm2Header {
+        version: 3,
+        ..Default::default()
+    };
+    let mut frames = Vec::new();
+    let mut savestate = None;
+
+    let mut state = ParseState::Newline;
+    let mut key = String::new();
+    let mut value = String::new();
+
+    let mut bytes_iter = reader.bytes();
+
+    loop {
+        let byte = match bytes_iter.next() {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => return Err(SupportError::Io(e)),
+            None => break,
+        };
+
+        let c = byte as char;
+        let is_whitespace = c == ' ' || c == '\t';
+        let is_rec_char = c == '|';
+        let is_newline = c == '\n' || c == '\r';
+
+        match state {
+            ParseState::Newline => {
+                if is_newline || is_whitespace {
+                    continue;
+                }
+                if is_rec_char {
+                    let mut line_buf = Vec::new();
+                    line_buf.push(byte);
+                    while let Some(res) = bytes_iter.next() {
+                        let b = res.map_err(SupportError::Io)?;
+                        if b == b'\n' || b == b'\r' {
+                            break;
+                        }
+                        line_buf.push(b);
+                    }
+                    parse_record_line(&line_buf, &header, &mut frames)?;
+                    state = ParseState::Newline;
+                } else {
+                    key.clear();
+                    value.clear();
+                    key.push(c);
+                    state = ParseState::Key;
+                }
+            }
+            ParseState::Key => {
+                if is_whitespace {
+                    state = ParseState::Separator;
+                } else if is_newline {
+                    install_value(&mut header, &mut savestate, &key, &value)?;
+                    state = ParseState::Newline;
+                } else {
+                    key.push(c);
+                }
+            }
+            ParseState::Separator => {
+                if is_newline {
+                    install_value(&mut header, &mut savestate, &key, &value)?;
+                    state = ParseState::Newline;
+                } else if !is_whitespace {
+                    value.push(c);
+                    state = ParseState::Value;
+                }
+            }
+            ParseState::Value => {
+                if is_newline {
+                    install_value(&mut header, &mut savestate, &key, &value)?;
+                    state = ParseState::Newline;
+                } else {
+                    value.push(c);
+                }
+            }
+        }
+    }
+
+    if state == ParseState::Value || state == ParseState::Key {
+        install_value(&mut header, &mut savestate, &key, &value)?;
+    }
+
+    Ok(Movie {
+        is_pal: header.pal_flag,
+        rom_hash: None,
+        data: TasData::Fm2(header),
+        frames,
+        savestate,
+    })
+}
+
+fn install_value(
+    header: &mut Fm2Header,
+    savestate: &mut Option<Vec<u8>>,
+    key: &str,
+    val: &str,
+) -> Result<(), SupportError> {
+    match key {
+        "emuVersion" => header.emu_version = val.to_string(),
+        "rerecordCount" => header.rerecord_count = val.parse().unwrap_or(0),
+        "palFlag" => header.pal_flag = val == "1",
+        "romFilename" => header.rom_filename = val.to_string(),
+        "guid" => header.guid = val.to_string(),
+        "fourscore" => header.fourscore = val == "1",
+        "microphone" => header.microphone = val == "1",
+        "port0" => header.ports[0] = val.parse().unwrap_or(0),
+        "port1" => header.ports[1] = val.parse().unwrap_or(0),
+        "port2" => header.ports[2] = val.parse().unwrap_or(0),
+        "FDS" => header.fds = val == "1",
+        "NewPPU" => header.ppu_flag = val == "1",
+        "RAMInitOption" => header.ram_init_option = val.parse().unwrap_or(0),
+        "RAMInitSeed" => header.ram_init_seed = val.parse().unwrap_or(0),
+        "comment" => header.comments.push(val.to_string()),
+        "subtitle" => header.subtitles.push(val.to_string()),
+        "binary" => header.binary_flag = val == "1",
+        "savestate" => {
+            if let Ok(bytes) = hex::decode(val) {
+                *savestate = Some(bytes);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn parse_record_line(
+    line: &[u8],
+    header: &Fm2Header,
+    frames: &mut Vec<InputFrame>,
+) -> Result<(), SupportError> {
+    let s = std::str::from_utf8(line)
+        .map_err(|_| SupportError::InvalidTasData("Invalid UTF-8 in movie record".to_string()))?;
+    let parts: Vec<&str> = s.split('|').collect();
+    if parts.len() < 3 {
+        return Ok(());
+    }
+
+    let commands_u8: u8 = parts[1].parse().unwrap_or(0);
+    let commands = FrameFlags::from_bits_truncate(commands_u8);
+    let mut frame = InputFrame {
+        commands,
+        ports: [0; 4],
+    };
+    let mut part_idx = 2;
+
+    if header.fourscore {
+        for i in 0..4 {
+            if part_idx < parts.len() {
+                frame.ports[i] = parse_joy(parts[part_idx]);
+                part_idx += 1;
+            }
+        }
+    } else {
+        for i in 0..2 {
+            if part_idx < parts.len() {
+                if header.ports[i] != 2 {
+                    frame.ports[i] = parse_joy(parts[part_idx]);
+                }
+                part_idx += 1;
+            }
+        }
+    }
+    frames.push(frame);
+    Ok(())
+}
+
+fn parse_joy(s: &str) -> u8 {
+    let mut mask = 0u8;
+    for c in s.chars() {
+        if c == '|' {
+            break;
+        }
+        mask <<= 1;
+        if c != '.' && c != ' ' {
+            mask |= 1;
+        }
+    }
+    mask
+}
+
+pub fn parse_str(s: &str) -> Result<Movie, SupportError> {
+    parse(Cursor::new(s))
+}

--- a/crates/nesium-support/src/tas/mod.rs
+++ b/crates/nesium-support/src/tas/mod.rs
@@ -1,0 +1,61 @@
+pub mod fm2;
+
+use bitflags::bitflags;
+
+/// Unified internal Movie IR used to drive the emulator.
+/// It is decoupled from specific file formats (FM2, BK2, etc.).
+#[derive(Debug, Clone, Default)]
+pub struct Movie {
+    /// Original TAS data and format-specific metadata.
+    pub data: TasData,
+
+    /// Expected ROM hash (MD5/SHA1).
+    pub rom_hash: Option<Vec<u8>>,
+
+    /// Whether it is PAL format.
+    pub is_pal: bool,
+
+    /// Input data for each frame.
+    pub frames: Vec<InputFrame>,
+
+    /// Initial savestate (if any).
+    pub savestate: Option<Vec<u8>>,
+}
+
+/// Represents different TAS format data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TasData {
+    Fm2(fm2::Fm2Header),
+    // Future: Bk2(bk2::Bk2Header),
+    Unknown,
+}
+
+impl Default for TasData {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InputFrame {
+    /// Command flags for the frame (Reset, Power, FDS, etc.)
+    pub commands: FrameFlags,
+    /// Controller bitmasks for up to 4 ports.
+    /// Bit mapping (matching nesium-core/standard NES):
+    /// 0: A, 1: B, 2: Select, 3: Start, 4: Up, 5: Down, 6: Left, 7: Right
+    pub ports: [u8; 4],
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+    pub struct FrameFlags: u8 {
+        const NONE = 0;
+        const RESET = 1 << 0;
+        const POWER = 1 << 1;
+        const FDS_INSERT = 1 << 2;
+        const FDS_SELECT = 1 << 3;
+        const VS_INSERT_COIN = 1 << 4;
+        const VS_INSERT_COIN2 = 1 << 5;
+        const VS_SERVICE = 1 << 6;
+    }
+}


### PR DESCRIPTION
- Rename `nesium-rewind` crate to `nesium-support` and reorganize internal modules
- Implement a robust FM2 movie parser in `nesium-support` using a state machine approach based on FCEUX logic
- Introduce a unified `Movie` IR to decouple format-specific parsing from emulation logic
- Integrate TAS playback into both native (`nesium-runtime`) and Web (`nesium-wasm`) runtimes, supporting input injection and initial savestate loading
- Add "Load TAS Movie..." menu item to Flutter UI (Desktop, Mobile, Web) with full i18n support (currently disabled)
- Standardize error handling with `thiserror` and improve code documentation across the `tas` module