### PR TITLE
fix(video): guard setVideoFilter platform channel call

### DIFF
--- a/apps/nesium_flutter/lib/features/settings/video_settings.dart
+++ b/apps/nesium_flutter/lib/features/settings/video_settings.dart
@@ -342,7 +342,9 @@ class VideoSettingsController extends Notifier<VideoSettings>
 
       // Only the main window has the native texture plugin registered.
       // Secondary windows (like Settings) should not update the texture directly.
-      if (ref.read(currentWindowKindProvider) == WindowKind.main) {
+      // Also, only Windows implements the setVideoFilter channel method (for native overlays).
+      if (ref.read(currentWindowKindProvider) == WindowKind.main &&
+          defaultTargetPlatform == TargetPlatform.windows) {
         await ref.read(nesTextureServiceProvider).setVideoFilter(filterMode);
       }
     }


### PR DESCRIPTION
Restrict the [setVideoFilter](cci:1://file:///Users/mikai/RustroverProjects/nesium/apps/nesium_flutter/lib/domain/nes_texture_service.dart:115:2-117:3) method call to the Windows platform. Since this method is currently only implemented for Windows native overlays, calling it on macOS or Linux was triggering a `MissingPluginException`.