### PR TITLE
refactor(debugger): modularize TilemapViewer into sub-components

### DIFF
--- a/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_models.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_models.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/foundation.dart';
+import 'package:nesium_flutter/bridge/api/events.dart' as bridge;
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+
+enum TilemapDisplayMode { defaultMode, grayscale, attributeView }
+
+enum TilemapCaptureMode { frameStart, vblankStart, scanline }
+
+@immutable
+class TileCoord {
+  const TileCoord(this.x, this.y);
+
+  final int x;
+  final int y;
+
+  @override
+  bool operator ==(Object other) =>
+      other is TileCoord && other.x == x && other.y == y;
+
+  @override
+  int get hashCode => Object.hash(x, y);
+}
+
+@immutable
+class TileInfo {
+  const TileInfo({
+    required this.tileX,
+    required this.tileY,
+    required this.ntIndex,
+    required this.tileIndex,
+    required this.tilemapAddress,
+    required this.tileAddressPpu,
+    required this.paletteIndex,
+    required this.paletteAddress,
+    required this.attrAddress,
+    required this.attrByte,
+  });
+
+  final int tileX;
+  final int tileY;
+  final int ntIndex;
+  final int tileIndex;
+  final int tilemapAddress;
+  final int tileAddressPpu;
+  final int paletteIndex;
+  final int paletteAddress;
+  final int attrAddress;
+  final int attrByte;
+
+  static TileInfo? compute(bridge.TilemapSnapshot snap, TileCoord tile) {
+    final tileX = tile.x;
+    final tileY = tile.y;
+    final ntX = tileX >= 32 ? 1 : 0;
+    final ntY = tileY >= 30 ? 1 : 0;
+    final ntIndex = ntY * 2 + ntX;
+
+    final tileXInNt = tileX % 32;
+    final tileYInNt = tileY % 30;
+
+    final ntLocalAddr = tileYInNt * 32 + tileXInNt;
+    final tilemapAddress = 0x2000 + ntIndex * 0x400 + ntLocalAddr;
+
+    final ciramBase = mirrorNametableToCiramOffset(ntIndex, snap.mirroring);
+    final tileCiramAddr = ciramBase + ntLocalAddr;
+    if (tileCiramAddr < 0 || tileCiramAddr >= snap.ciram.length) return null;
+
+    final tileIndex = snap.ciram[tileCiramAddr];
+
+    final attrLocalAddr = 0x3C0 + (tileYInNt ~/ 4) * 8 + (tileXInNt ~/ 4);
+    final attrAddress = 0x2000 + ntIndex * 0x400 + attrLocalAddr;
+    final attrCiramAddr = ciramBase + attrLocalAddr;
+    final attrByte = attrCiramAddr >= 0 && attrCiramAddr < snap.ciram.length
+        ? snap.ciram[attrCiramAddr]
+        : 0;
+
+    final shift = ((tileYInNt % 4) ~/ 2) * 4 + ((tileXInNt % 4) ~/ 2) * 2;
+    final paletteIndex = (attrByte >> shift) & 0x03;
+    final paletteAddress = 0x3F00 + paletteIndex * 4;
+
+    final tileAddressPpu = snap.bgPatternBase + tileIndex * 16;
+
+    return TileInfo(
+      tileX: tileX,
+      tileY: tileY,
+      ntIndex: ntIndex,
+      tileIndex: tileIndex,
+      tilemapAddress: tilemapAddress,
+      tileAddressPpu: tileAddressPpu,
+      paletteIndex: paletteIndex,
+      paletteAddress: paletteAddress,
+      attrAddress: attrAddress,
+      attrByte: attrByte,
+    );
+  }
+
+  static int mirrorNametableToCiramOffset(
+    int ntIndex,
+    bridge.TilemapMirroring mirroring,
+  ) {
+    final physicalNt = switch (mirroring) {
+      bridge.TilemapMirroring.horizontal =>
+        (ntIndex == 0 || ntIndex == 1) ? 0 : 1,
+      bridge.TilemapMirroring.vertical =>
+        (ntIndex == 0 || ntIndex == 2) ? 0 : 1,
+      bridge.TilemapMirroring.fourScreen => ntIndex.clamp(0, 1),
+      bridge.TilemapMirroring.singleScreenLower => 0,
+      bridge.TilemapMirroring.singleScreenUpper => 1,
+      bridge.TilemapMirroring.mapperControlled => ntIndex.clamp(0, 1),
+    };
+    return physicalNt * 0x400;
+  }
+}
+
+String formatHex(int value, {int width = 4}) {
+  return '\$${value.toRadixString(16).toUpperCase().padLeft(width, '0')}';
+}
+
+String mirroringLabel(AppLocalizations l10n, bridge.TilemapMirroring m) {
+  switch (m) {
+    case bridge.TilemapMirroring.horizontal:
+      return l10n.tilemapMirroringHorizontal;
+    case bridge.TilemapMirroring.vertical:
+      return l10n.tilemapMirroringVertical;
+    case bridge.TilemapMirroring.fourScreen:
+      return l10n.tilemapMirroringFourScreen;
+    case bridge.TilemapMirroring.singleScreenLower:
+      return l10n.tilemapMirroringSingleScreenLower;
+    case bridge.TilemapMirroring.singleScreenUpper:
+      return l10n.tilemapMirroringSingleScreenUpper;
+    case bridge.TilemapMirroring.mapperControlled:
+      return l10n.tilemapMirroringMapperControlled;
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_painters.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_painters.dart
@@ -1,0 +1,261 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/bridge/api/events.dart' as bridge;
+import 'tilemap_models.dart';
+
+class TilePreviewPainter extends CustomPainter {
+  TilePreviewPainter({required this.snapshot, required this.info});
+
+  final bridge.TilemapSnapshot snapshot;
+  final TileInfo info;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final sx = size.width / 8;
+    final sy = size.height / 8;
+    final paint = Paint();
+
+    final base = snapshot.bgPatternBase + info.tileIndex * 16;
+    for (var py = 0; py < 8; py++) {
+      final o = base + py;
+      if (o + 8 >= snapshot.chr.length) break;
+      final plane0 = snapshot.chr[o];
+      final plane1 = snapshot.chr[o + 8];
+      for (var px = 0; px < 8; px++) {
+        final bit = 7 - px;
+        final lo = (plane0 >> bit) & 1;
+        final hi = (plane1 >> bit) & 1;
+        final colorIndex = (hi << 1) | lo;
+        final nesColor = _nesColorIndex(
+          snapshot,
+          paletteIndex: info.paletteIndex,
+          colorIndex: colorIndex,
+        );
+        paint.color = _colorFromNes(snapshot.rgbaPalette, nesColor);
+        canvas.drawRect(Rect.fromLTWH(px * sx, py * sy, sx, sy), paint);
+      }
+    }
+  }
+
+  int _nesColorIndex(
+    bridge.TilemapSnapshot snap, {
+    required int paletteIndex,
+    required int colorIndex,
+  }) {
+    final pal = snap.palette;
+    if (pal.isEmpty) return 0;
+    if (colorIndex == 0) return pal[0] & 0x3F;
+    final idx = paletteIndex * 4 + colorIndex;
+    if (idx < 0 || idx >= pal.length) return 0;
+    return pal[idx] & 0x3F;
+  }
+
+  Color _colorFromNes(Uint8List rgbaPalette, int nesColor) {
+    final base = (nesColor & 0x3F) * 4;
+    if (base + 3 >= rgbaPalette.length) return const Color(0xFF000000);
+    final r = rgbaPalette[base];
+    final g = rgbaPalette[base + 1];
+    final b = rgbaPalette[base + 2];
+    final a = rgbaPalette[base + 3];
+    return Color.fromARGB(a, r, g, b);
+  }
+
+  @override
+  bool shouldRepaint(TilePreviewPainter oldDelegate) {
+    return oldDelegate.info != info || oldDelegate.snapshot != snapshot;
+  }
+}
+
+class TilemapGridPainter extends CustomPainter {
+  final bool showTileGrid;
+  final bool showAttributeGrid;
+  final bool showAttributeGrid32;
+  final bool showNametableDelimiters;
+  final bool showScrollOverlay;
+  final List<Rect> scrollOverlayRects;
+  final TileCoord? hoveredTile;
+  final TileCoord? selectedTile;
+
+  TilemapGridPainter({
+    required this.showTileGrid,
+    required this.showAttributeGrid,
+    required this.showAttributeGrid32,
+    required this.showNametableDelimiters,
+    required this.showScrollOverlay,
+    required this.scrollOverlayRects,
+    required this.hoveredTile,
+    required this.selectedTile,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Tilemap is 512x480 (2x2 nametables of 256x240 each)
+    const logicalWidth = 512.0;
+    const logicalHeight = 480.0;
+
+    // Calculate scaling factor
+    final scaleX = size.width / logicalWidth;
+    final scaleY = size.height / logicalHeight;
+
+    // Draw 8×8 tile grid
+    if (showTileGrid) {
+      final paint = Paint()
+        ..color = Colors.white.withValues(alpha: 0.5)
+        ..strokeWidth = 1.0
+        ..style = PaintingStyle.stroke;
+
+      for (var y = 0; y <= logicalHeight; y += 8) {
+        final scaledY = y * scaleY;
+        canvas.drawLine(Offset(0, scaledY), Offset(size.width, scaledY), paint);
+      }
+      for (var x = 0; x <= logicalWidth; x += 8) {
+        final scaledX = x * scaleX;
+        canvas.drawLine(
+          Offset(scaledX, 0),
+          Offset(scaledX, size.height),
+          paint,
+        );
+      }
+    }
+
+    // Draw 16×16 attribute grid
+    if (showAttributeGrid) {
+      final paint = Paint()
+        ..color = Colors.cyan.withValues(alpha: 0.7)
+        ..strokeWidth = 0.8
+        ..style = PaintingStyle.stroke;
+
+      for (var y = 0; y <= logicalHeight; y += 16) {
+        final scaledY = y * scaleY;
+        canvas.drawLine(Offset(0, scaledY), Offset(size.width, scaledY), paint);
+      }
+      for (var x = 0; x <= logicalWidth; x += 16) {
+        final scaledX = x * scaleX;
+        canvas.drawLine(
+          Offset(scaledX, 0),
+          Offset(scaledX, size.height),
+          paint,
+        );
+      }
+    }
+
+    // Draw 32×32 attribute grid (attribute bytes boundaries)
+    if (showAttributeGrid32) {
+      final paint = Paint()
+        ..color = Colors.orange.withValues(alpha: 0.55)
+        ..strokeWidth = 1.0
+        ..style = PaintingStyle.stroke;
+
+      for (var y = 0; y <= logicalHeight; y += 32) {
+        final scaledY = y * scaleY;
+        canvas.drawLine(Offset(0, scaledY), Offset(size.width, scaledY), paint);
+      }
+      for (var x = 0; x <= logicalWidth; x += 32) {
+        final scaledX = x * scaleX;
+        canvas.drawLine(
+          Offset(scaledX, 0),
+          Offset(scaledX, size.height),
+          paint,
+        );
+      }
+    }
+
+    // Draw nametable delimiters (256×240 boundaries)
+    if (showNametableDelimiters) {
+      final paint = Paint()
+        ..color = Colors.white.withValues(alpha: 0.9)
+        ..strokeWidth = 1.0
+        ..style = PaintingStyle.stroke;
+
+      // Vertical delimiter at x=256
+      final verticalX = 256.0 * scaleX;
+      canvas.drawLine(
+        Offset(verticalX, 0),
+        Offset(verticalX, size.height),
+        paint,
+      );
+
+      // Horizontal delimiter at y=240
+      final horizontalY = 240.0 * scaleY;
+      canvas.drawLine(
+        Offset(0, horizontalY),
+        Offset(size.width, horizontalY),
+        paint,
+      );
+    }
+
+    if (showScrollOverlay && scrollOverlayRects.isNotEmpty) {
+      final outline = Paint()
+        ..color = Colors.pinkAccent.withValues(alpha: 0.9)
+        ..strokeWidth = 2.0
+        ..style = PaintingStyle.stroke;
+      final fill = Paint()
+        ..color = Colors.pinkAccent.withValues(alpha: 0.12)
+        ..style = PaintingStyle.fill;
+
+      for (final r in scrollOverlayRects) {
+        final scaled = Rect.fromLTWH(
+          r.left * scaleX,
+          r.top * scaleY,
+          r.width * scaleX,
+          r.height * scaleY,
+        );
+        canvas.drawRect(scaled, fill);
+        canvas.drawRect(scaled, outline);
+      }
+    }
+
+    // Hovered tile outline
+    if (hoveredTile != null) {
+      final paint = Paint()
+        ..color = Colors.white.withValues(alpha: 0.9)
+        ..strokeWidth = 2.0
+        ..style = PaintingStyle.stroke;
+
+      final rect = Rect.fromLTWH(
+        hoveredTile!.x * 8.0 * scaleX,
+        hoveredTile!.y * 8.0 * scaleY,
+        8.0 * scaleX,
+        8.0 * scaleY,
+      );
+      canvas.drawRect(rect, paint);
+    }
+
+    // Selected tile outline
+    if (selectedTile != null) {
+      final paint = Paint()
+        ..color = Colors.yellow.withValues(alpha: 0.95)
+        ..strokeWidth = 2.5
+        ..style = PaintingStyle.stroke;
+
+      final rect = Rect.fromLTWH(
+        selectedTile!.x * 8.0 * scaleX,
+        selectedTile!.y * 8.0 * scaleY,
+        8.0 * scaleX,
+        8.0 * scaleY,
+      );
+      canvas.drawRect(rect, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(TilemapGridPainter oldDelegate) {
+    return showTileGrid != oldDelegate.showTileGrid ||
+        showAttributeGrid != oldDelegate.showAttributeGrid ||
+        showAttributeGrid32 != oldDelegate.showAttributeGrid32 ||
+        hoveredTile != oldDelegate.hoveredTile ||
+        selectedTile != oldDelegate.selectedTile ||
+        showNametableDelimiters != oldDelegate.showNametableDelimiters ||
+        showScrollOverlay != oldDelegate.showScrollOverlay ||
+        !_rectListEquals(scrollOverlayRects, oldDelegate.scrollOverlayRects);
+  }
+
+  bool _rectListEquals(List<Rect> a, List<Rect> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_settings_dialog.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_settings_dialog.dart
@@ -1,0 +1,295 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+import 'package:nesium_flutter/widgets/animated_dropdown_menu.dart';
+import 'tilemap_models.dart';
+
+Future<void> showTilemapSettingsMenu({
+  required BuildContext context,
+  required Offset buttonPosition,
+  required Size buttonSize,
+  required TilemapDisplayMode displayMode,
+  required bool showTileGrid,
+  required bool showAttributeGrid,
+  required bool showAttributeGrid32,
+  required bool showNametableDelimiters,
+  required bool showScrollOverlay,
+  required TilemapCaptureMode captureMode,
+  required int scanline,
+  required int dot,
+  required ValueChanged<TilemapDisplayMode> onDisplayModeChanged,
+  required ValueChanged<bool?> onShowTileGridChanged,
+  required ValueChanged<bool?> onShowAttributeGridChanged,
+  required ValueChanged<bool?> onShowAttributeGrid32Changed,
+  required ValueChanged<bool?> onShowNametableDelimitersChanged,
+  required ValueChanged<bool?> onShowScrollOverlayChanged,
+  required ValueChanged<TilemapCaptureMode> onCaptureModeChanged,
+  required void Function(int scanline, int dot) onScanlineDotChanged,
+}) async {
+  final l10n = AppLocalizations.of(context)!;
+  final theme = Theme.of(context);
+  final RenderBox overlay =
+      Overlay.of(context).context.findRenderObject() as RenderBox;
+
+  await showMenu<void>(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      buttonPosition.dx + buttonSize.width - 280,
+      buttonPosition.dy + buttonSize.height + 4,
+      overlay.size.width - buttonPosition.dx - buttonSize.width,
+      0,
+    ),
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    items: [
+      PopupMenuItem<void>(
+        onTap: null,
+        height: 32,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Text(
+          l10n.tilemapOverlay,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      PopupMenuItem<void>(
+        enabled: false,
+        padding: EdgeInsets.zero,
+        child: StatefulBuilder(
+          builder: (context, setMenuState) => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 6,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        l10n.tilemapDisplayMode,
+                        style: theme.textTheme.bodySmall,
+                      ),
+                    ),
+                    SizedBox(
+                      width: 180,
+                      child: AnimatedDropdownMenu<TilemapDisplayMode>(
+                        density: AnimatedDropdownMenuDensity.compact,
+                        value: displayMode,
+                        entries: [
+                          DropdownMenuEntry(
+                            value: TilemapDisplayMode.defaultMode,
+                            label: l10n.tilemapDisplayModeDefault,
+                          ),
+                          DropdownMenuEntry(
+                            value: TilemapDisplayMode.grayscale,
+                            label: l10n.tilemapDisplayModeGrayscale,
+                          ),
+                          DropdownMenuEntry(
+                            value: TilemapDisplayMode.attributeView,
+                            label: l10n.tilemapDisplayModeAttributeView,
+                          ),
+                        ],
+                        onSelected: (v) {
+                          onDisplayModeChanged(v);
+                          setMenuState(() {});
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              CheckboxListTile(
+                dense: true,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                title: Text(l10n.tilemapTileGrid),
+                value: showTileGrid,
+                onChanged: (v) {
+                  onShowTileGridChanged(v);
+                  setMenuState(() {});
+                },
+              ),
+              CheckboxListTile(
+                dense: true,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                title: Text(l10n.tilemapAttrGrid),
+                value: showAttributeGrid,
+                onChanged: (v) {
+                  onShowAttributeGridChanged(v);
+                  setMenuState(() {});
+                },
+              ),
+              CheckboxListTile(
+                dense: true,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                title: Text(l10n.tilemapAttrGrid32),
+                value: showAttributeGrid32,
+                onChanged: (v) {
+                  onShowAttributeGrid32Changed(v);
+                  setMenuState(() {});
+                },
+              ),
+              CheckboxListTile(
+                dense: true,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                title: Text(l10n.tilemapNtBounds),
+                value: showNametableDelimiters,
+                onChanged: (v) {
+                  onShowNametableDelimitersChanged(v);
+                  setMenuState(() {});
+                },
+              ),
+              CheckboxListTile(
+                dense: true,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                title: Text(l10n.tilemapScrollOverlay),
+                value: showScrollOverlay,
+                onChanged: (v) {
+                  onShowScrollOverlayChanged(v);
+                  setMenuState(() {});
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+      const PopupMenuDivider(height: 1),
+      PopupMenuItem<void>(
+        onTap: null,
+        height: 32,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Text(
+          l10n.tilemapCapture,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.primary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      PopupMenuItem<void>(
+        onTap: () {},
+        padding: EdgeInsets.zero,
+        child: StatefulBuilder(
+          builder: (context, setMenuState) => RadioGroup<TilemapCaptureMode>(
+            groupValue: captureMode,
+            onChanged: (v) {
+              if (v == null) return;
+              onCaptureModeChanged(v);
+              setMenuState(() {});
+            },
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                RadioListTile<TilemapCaptureMode>(
+                  dense: true,
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                  title: Text(l10n.tilemapCaptureFrameStart),
+                  value: TilemapCaptureMode.frameStart,
+                ),
+                RadioListTile<TilemapCaptureMode>(
+                  dense: true,
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                  title: Text(l10n.tilemapCaptureVblankStart),
+                  value: TilemapCaptureMode.vblankStart,
+                ),
+                RadioListTile<TilemapCaptureMode>(
+                  dense: true,
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                  title: Text(l10n.tilemapCaptureManual),
+                  value: TilemapCaptureMode.scanline,
+                ),
+                if (captureMode == TilemapCaptureMode.scanline) ...[
+                  const PopupMenuDivider(height: 1),
+                  PopupMenuItem<void>(
+                    onTap: () {},
+                    padding: EdgeInsets.zero,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: _ScanlineControls(
+                        scanline: scanline,
+                        dot: dot,
+                        onChanged: (s, d) {
+                          onScanlineDotChanged(s, d);
+                          setMenuState(() {});
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+class _ScanlineControls extends StatelessWidget {
+  const _ScanlineControls({
+    required this.scanline,
+    required this.dot,
+    required this.onChanged,
+  });
+
+  final int scanline;
+  final int dot;
+  final void Function(int scanline, int dot) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('${l10n.tilemapScanline}:', style: theme.textTheme.bodySmall),
+        const SizedBox(height: 4),
+        TextField(
+          controller: TextEditingController(text: scanline.toString())
+            ..selection = TextSelection.fromPosition(
+              TextPosition(offset: scanline.toString().length),
+            ),
+          decoration: const InputDecoration(
+            isDense: true,
+            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            border: OutlineInputBorder(),
+            hintText: '-1 ~ 260',
+          ),
+          keyboardType: TextInputType.number,
+          onSubmitted: (v) {
+            final value = int.tryParse(v);
+            if (value != null && value >= -1 && value <= 260) {
+              onChanged(value, dot);
+            }
+          },
+        ),
+        const SizedBox(height: 12),
+        Text('${l10n.tilemapDot}:', style: theme.textTheme.bodySmall),
+        const SizedBox(height: 4),
+        TextField(
+          controller: TextEditingController(text: dot.toString())
+            ..selection = TextSelection.fromPosition(
+              TextPosition(offset: dot.toString().length),
+            ),
+          decoration: const InputDecoration(
+            isDense: true,
+            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            border: OutlineInputBorder(),
+            hintText: '0 ~ 340',
+          ),
+          keyboardType: TextInputType.number,
+          onSubmitted: (v) {
+            final value = int.tryParse(v);
+            if (value != null && value >= 0 && value <= 340) {
+              onChanged(scanline, value);
+            }
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_side_panel.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_side_panel.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/bridge/api/events.dart' as bridge;
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+import 'package:nesium_flutter/widgets/animated_dropdown_menu.dart';
+import 'package:nesium_flutter/widgets/single_position_scrollbar.dart';
+import 'tilemap_models.dart';
+import 'tilemap_widgets.dart';
+
+class TilemapSidePanel extends StatelessWidget {
+  const TilemapSidePanel({
+    super.key,
+    required this.snapshot,
+    required this.selectedTile,
+    required this.showTileGrid,
+    required this.showAttributeGrid,
+    required this.showAttributeGrid32,
+    required this.showNametableDelimiters,
+    required this.showScrollOverlay,
+    required this.displayMode,
+    required this.captureMode,
+    required this.scanlineController,
+    required this.dotController,
+    required this.onShowTileGridChanged,
+    required this.onShowAttributeGridChanged,
+    required this.onShowAttributeGrid32Changed,
+    required this.onShowNametableDelimitersChanged,
+    required this.onShowScrollOverlayChanged,
+    required this.onDisplayModeChanged,
+    required this.onCaptureModeChanged,
+    required this.onScanlineSubmitted,
+    required this.onDotSubmitted,
+  });
+
+  final bridge.TilemapSnapshot? snapshot;
+  final TileCoord? selectedTile;
+  final bool showTileGrid;
+  final bool showAttributeGrid;
+  final bool showAttributeGrid32;
+  final bool showNametableDelimiters;
+  final bool showScrollOverlay;
+  final TilemapDisplayMode displayMode;
+  final TilemapCaptureMode captureMode;
+  final TextEditingController scanlineController;
+  final TextEditingController dotController;
+
+  final ValueChanged<bool?> onShowTileGridChanged;
+  final ValueChanged<bool?> onShowAttributeGridChanged;
+  final ValueChanged<bool?> onShowAttributeGrid32Changed;
+  final ValueChanged<bool?> onShowNametableDelimitersChanged;
+  final ValueChanged<bool?> onShowScrollOverlayChanged;
+  final ValueChanged<TilemapDisplayMode> onDisplayModeChanged;
+  final ValueChanged<TilemapCaptureMode> onCaptureModeChanged;
+  final ValueChanged<String> onScanlineSubmitted;
+  final ValueChanged<String> onDotSubmitted;
+
+  @override
+  Widget build(BuildContext context) {
+    final snap = snapshot;
+    final selected = selectedTile != null && snap != null
+        ? TileInfo.compute(snap, selectedTile!)
+        : null;
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerLowest,
+        border: Border(
+          left: BorderSide(color: colorScheme.outlineVariant, width: 1),
+        ),
+      ),
+      child: SinglePositionScrollbar(
+        thumbVisibility: true,
+        builder: (context, controller) {
+          return ListView(
+            controller: controller,
+            primary: false,
+            padding: const EdgeInsets.all(12),
+            children: [
+              _sideSection(
+                context,
+                title: l10n.tilemapPanelDisplay,
+                child: Column(
+                  children: [
+                    _displayModeDropdown(context),
+                    const SizedBox(height: 4),
+                    CheckboxListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.trailing,
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(l10n.tilemapTileGrid),
+                      value: showTileGrid,
+                      onChanged: onShowTileGridChanged,
+                    ),
+                    CheckboxListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.trailing,
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(l10n.tilemapAttrGrid),
+                      value: showAttributeGrid,
+                      onChanged: onShowAttributeGridChanged,
+                    ),
+                    CheckboxListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.trailing,
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(l10n.tilemapAttrGrid32),
+                      value: showAttributeGrid32,
+                      onChanged: onShowAttributeGrid32Changed,
+                    ),
+                    CheckboxListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.trailing,
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(l10n.tilemapNtBounds),
+                      value: showNametableDelimiters,
+                      onChanged: onShowNametableDelimitersChanged,
+                    ),
+                    CheckboxListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.trailing,
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(l10n.tilemapScrollOverlay),
+                      value: showScrollOverlay,
+                      onChanged: onShowScrollOverlayChanged,
+                    ),
+                  ],
+                ),
+              ),
+              _sideSection(
+                context,
+                title: l10n.tilemapCapture,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    RadioGroup<TilemapCaptureMode>(
+                      groupValue: captureMode,
+                      onChanged: (v) {
+                        if (v == null) return;
+                        onCaptureModeChanged(v);
+                      },
+                      child: Column(
+                        children: [
+                          RadioListTile<TilemapCaptureMode>(
+                            dense: true,
+                            visualDensity: VisualDensity.compact,
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(l10n.tilemapCaptureFrameStart),
+                            value: TilemapCaptureMode.frameStart,
+                          ),
+                          RadioListTile<TilemapCaptureMode>(
+                            dense: true,
+                            visualDensity: VisualDensity.compact,
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(l10n.tilemapCaptureVblankStart),
+                            value: TilemapCaptureMode.vblankStart,
+                          ),
+                          RadioListTile<TilemapCaptureMode>(
+                            dense: true,
+                            visualDensity: VisualDensity.compact,
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(l10n.tilemapCaptureManual),
+                            value: TilemapCaptureMode.scanline,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: _numberFieldModern(
+                            context,
+                            label: l10n.tilemapScanline,
+                            enabled: captureMode == TilemapCaptureMode.scanline,
+                            controller: scanlineController,
+                            hint: '-1 ~ 260',
+                            onSubmitted: onScanlineSubmitted,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: _numberFieldModern(
+                            context,
+                            label: l10n.tilemapDot,
+                            enabled: captureMode == TilemapCaptureMode.scanline,
+                            controller: dotController,
+                            hint: '0 ~ 340',
+                            onSubmitted: onDotSubmitted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              _sideSection(
+                context,
+                title: l10n.tilemapPanelTilemap,
+                child: Column(
+                  children: [
+                    _kvModern(l10n.tilemapInfoSize, '64×60'),
+                    _kvModern(l10n.tilemapInfoSizePx, '512×480'),
+                    _kvModern(
+                      l10n.tilemapInfoTilemapAddress,
+                      formatHex(0x2000),
+                    ),
+                    _kvModern(
+                      l10n.tilemapInfoTilesetAddress,
+                      snap != null ? formatHex(snap.bgPatternBase) : '—',
+                    ),
+                    _kvModern(
+                      l10n.tilemapInfoMirroring,
+                      snap != null ? mirroringLabel(l10n, snap.mirroring) : '—',
+                    ),
+                    _kvModern(
+                      l10n.tilemapInfoTileFormat,
+                      l10n.tilemapInfoTileFormat2bpp,
+                    ),
+                  ],
+                ),
+              ),
+              _sideSection(
+                context,
+                title: l10n.tilemapPanelSelectedTile,
+                child: (selected == null || snap == null)
+                    ? _emptyHint(colorScheme.onSurfaceVariant)
+                    : TileInfoCard(info: selected, snapshot: snap),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _sideSection(
+    BuildContext context, {
+    required String title,
+    required Widget child,
+  }) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        elevation: 0,
+        color: colorScheme.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 10),
+              child,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _emptyHint(Color color) {
+    return Text('—', style: TextStyle(color: color));
+  }
+
+  Widget _numberFieldModern(
+    BuildContext context, {
+    required String label,
+    required bool enabled,
+    required TextEditingController controller,
+    required String hint,
+    ValueChanged<String>? onSubmitted,
+  }) {
+    return TextField(
+      enabled: enabled,
+      controller: controller
+        ..selection = TextSelection.fromPosition(
+          TextPosition(offset: controller.text.length),
+        ),
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        isDense: true,
+        filled: true,
+        fillColor: Theme.of(context).colorScheme.surfaceContainerLowest,
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
+      ),
+      keyboardType: TextInputType.number,
+      onSubmitted: onSubmitted,
+    );
+  }
+
+  Widget _kvModern(String k, String v) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(k, style: const TextStyle(color: Colors.black54)),
+          ),
+          Text(v, style: const TextStyle(fontWeight: FontWeight.w600)),
+        ],
+      ),
+    );
+  }
+
+  Widget _displayModeDropdown(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            l10n.tilemapDisplayMode,
+            style: theme.textTheme.bodySmall,
+          ),
+        ),
+        SizedBox(
+          width: 180,
+          child: AnimatedDropdownMenu<TilemapDisplayMode>(
+            density: AnimatedDropdownMenuDensity.compact,
+            value: displayMode,
+            entries: [
+              DropdownMenuEntry(
+                value: TilemapDisplayMode.defaultMode,
+                label: l10n.tilemapDisplayModeDefault,
+              ),
+              DropdownMenuEntry(
+                value: TilemapDisplayMode.grayscale,
+                label: l10n.tilemapDisplayModeGrayscale,
+              ),
+              DropdownMenuEntry(
+                value: TilemapDisplayMode.attributeView,
+                label: l10n.tilemapDisplayModeAttributeView,
+              ),
+            ],
+            onSelected: onDisplayModeChanged,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_widgets.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tilemap/tilemap_widgets.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/bridge/api/events.dart' as bridge;
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+import 'tilemap_models.dart';
+import 'tilemap_painters.dart';
+
+class TilePreview extends StatelessWidget {
+  const TilePreview({super.key, required this.snapshot, required this.info});
+
+  final bridge.TilemapSnapshot snapshot;
+  final TileInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 64,
+          height: 64,
+          child: CustomPaint(
+            painter: TilePreviewPainter(snapshot: snapshot, info: info),
+          ),
+        ),
+        const SizedBox(height: 8),
+        PaletteStrip(snapshot: snapshot, info: info),
+      ],
+    );
+  }
+}
+
+class PaletteStrip extends StatelessWidget {
+  const PaletteStrip({super.key, required this.snapshot, required this.info});
+
+  final bridge.TilemapSnapshot snapshot;
+  final TileInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = List<Color>.generate(4, (i) {
+      int nes;
+      if (snapshot.palette.isEmpty) {
+        nes = 0;
+      } else if (i == 0) {
+        nes = snapshot.palette[0];
+      } else {
+        final idx = info.paletteIndex * 4 + i;
+        nes = snapshot.palette[idx.clamp(0, snapshot.palette.length - 1)];
+      }
+
+      final base = (nes & 0x3F) * 4;
+      if (base + 3 >= snapshot.rgbaPalette.length) {
+        return const Color(0xFF000000);
+      }
+      return Color.fromARGB(
+        snapshot.rgbaPalette[base + 3],
+        snapshot.rgbaPalette[base],
+        snapshot.rgbaPalette[base + 1],
+        snapshot.rgbaPalette[base + 2],
+      );
+    });
+
+    return Row(
+      children: [
+        for (final c in colors)
+          Container(
+            width: 16,
+            height: 16,
+            margin: const EdgeInsets.only(right: 4),
+            decoration: BoxDecoration(
+              color: c,
+              border: Border.all(color: Colors.black26),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class TileInfoTable extends StatelessWidget {
+  const TileInfoTable({super.key, required this.info});
+
+  final TileInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    String hex(int v, {int width = 4}) =>
+        '\$${v.toRadixString(16).toUpperCase().padLeft(width, '0')}';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _row(l10n.tilemapLabelColumnRow, '${info.tileX}, ${info.tileY}'),
+        _row(l10n.tilemapLabelXY, '${info.tileX * 8}, ${info.tileY * 8}'),
+        _row(l10n.tilemapLabelSize, '8×8'),
+        const Divider(height: 16),
+        _row(l10n.tilemapLabelTilemapAddress, hex(info.tilemapAddress)),
+        _row(l10n.tilemapLabelTileIndex, hex(info.tileIndex, width: 2)),
+        _row(l10n.tilemapLabelTileAddressPpu, hex(info.tileAddressPpu)),
+        const Divider(height: 16),
+        _row(l10n.tilemapLabelPaletteIndex, '${info.paletteIndex}'),
+        _row(l10n.tilemapLabelPaletteAddress, hex(info.paletteAddress)),
+        const Divider(height: 16),
+        _row(l10n.tilemapLabelAttributeAddress, hex(info.attrAddress)),
+        _row(l10n.tilemapLabelAttributeData, hex(info.attrByte, width: 2)),
+      ],
+    );
+  }
+
+  Widget _row(String k, String v) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(k, style: const TextStyle(color: Colors.black54)),
+          ),
+          Text(v),
+        ],
+      ),
+    );
+  }
+}
+
+class TileInfoCard extends StatelessWidget {
+  const TileInfoCard({super.key, required this.info, required this.snapshot});
+
+  final TileInfo info;
+  final bridge.TilemapSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final labelStyle = theme.textTheme.bodySmall?.copyWith(
+      color: colorScheme.onSurfaceVariant,
+    );
+    final valueStyle = theme.textTheme.bodySmall?.copyWith(
+      fontWeight: FontWeight.w600,
+    );
+
+    String hex(int v, {int width = 4}) =>
+        '\$${v.toRadixString(16).toUpperCase().padLeft(width, '0')}';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 84,
+              child: TilePreview(snapshot: snapshot, info: info),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                children: [
+                  _metaRow(
+                    label: l10n.tilemapLabelColumnRow,
+                    value: '${info.tileX}, ${info.tileY}',
+                    labelStyle: labelStyle,
+                    valueStyle: valueStyle,
+                  ),
+                  _metaRow(
+                    label: l10n.tilemapLabelXY,
+                    value: '${info.tileX * 8}, ${info.tileY * 8}',
+                    labelStyle: labelStyle,
+                    valueStyle: valueStyle,
+                  ),
+                  _metaRow(
+                    label: l10n.tilemapLabelSize,
+                    value: '8×8',
+                    labelStyle: labelStyle,
+                    valueStyle: valueStyle,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        const Divider(height: 1),
+        const SizedBox(height: 10),
+        _kv(
+          l10n.tilemapSelectedTileTilemap,
+          hex(info.tilemapAddress),
+          labelStyle,
+          valueStyle,
+        ),
+        _kv(
+          l10n.tilemapSelectedTileTileIdx,
+          hex(info.tileIndex, width: 2),
+          labelStyle,
+          valueStyle,
+        ),
+        _kv(
+          l10n.tilemapSelectedTileTilePpu,
+          hex(info.tileAddressPpu),
+          labelStyle,
+          valueStyle,
+        ),
+        _kv(
+          l10n.tilemapSelectedTilePalette,
+          '${info.paletteIndex}  ${hex(info.paletteAddress)}',
+          labelStyle,
+          valueStyle,
+        ),
+        _kv(
+          l10n.tilemapSelectedTileAttr,
+          '${hex(info.attrAddress)}  ${hex(info.attrByte, width: 2)}',
+          labelStyle,
+          valueStyle,
+        ),
+      ],
+    );
+  }
+
+  Widget _kv(
+    String label,
+    String value,
+    TextStyle? labelStyle,
+    TextStyle? valueStyle,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Expanded(child: Text(label, style: labelStyle)),
+          Text(value, style: valueStyle),
+        ],
+      ),
+    );
+  }
+
+  Widget _metaRow({
+    required String label,
+    required String value,
+    required TextStyle? labelStyle,
+    required TextStyle? valueStyle,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Expanded(child: Text(label, style: labelStyle)),
+          Text(value, style: valueStyle),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tilemap_viewer.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tilemap_viewer.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,8 +10,12 @@ import 'package:nesium_flutter/features/debugger/viewer_skeletonizer.dart';
 import 'package:nesium_flutter/l10n/app_localizations.dart';
 import 'package:nesium_flutter/logging/app_logger.dart';
 import 'package:nesium_flutter/platform/platform_capabilities.dart';
-import 'package:nesium_flutter/widgets/animated_dropdown_menu.dart';
-import 'package:nesium_flutter/widgets/single_position_scrollbar.dart';
+
+import 'tilemap/tilemap_models.dart';
+import 'tilemap/tilemap_painters.dart';
+import 'tilemap/tilemap_settings_dialog.dart';
+import 'tilemap/tilemap_side_panel.dart';
+import 'tilemap/tilemap_widgets.dart';
 
 /// Tilemap Viewer that displays NES nametables via a Flutter Texture.
 class TilemapViewer extends ConsumerStatefulWidget {
@@ -22,15 +25,9 @@ class TilemapViewer extends ConsumerStatefulWidget {
   ConsumerState<TilemapViewer> createState() => _TilemapViewerState();
 }
 
-enum _TilemapDisplayMode { defaultMode, grayscale, attributeView }
-
 class _TilemapViewerState extends ConsumerState<TilemapViewer> {
   static const int _width = 512;
   static const int _height = 480;
-  static const int _minScanline = -1;
-  static const int _maxScanline = 260;
-  static const int _minDot = 0;
-  static const int _maxDot = 340;
 
   final NesTextureService _textureService = NesTextureService();
   int? _tilemapTextureId;
@@ -41,7 +38,7 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
   bridge.TilemapSnapshot? _tilemapSnapshot;
 
   // Capture mode state
-  _TilemapCaptureMode _captureMode = _TilemapCaptureMode.vblankStart;
+  TilemapCaptureMode _captureMode = TilemapCaptureMode.vblankStart;
   int _scanline = 0;
   int _dot = 0;
   late final TextEditingController _scanlineController = TextEditingController(
@@ -57,11 +54,11 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
   bool _showAttributeGrid32 = false;
   bool _showNametableDelimiters = true;
   bool _showScrollOverlay = false;
-  _TilemapDisplayMode _displayMode = _TilemapDisplayMode.defaultMode;
+  TilemapDisplayMode _displayMode = TilemapDisplayMode.defaultMode;
 
   // Hover/selection
-  _TileCoord? _hoveredTile;
-  _TileCoord? _selectedTile;
+  TileCoord? _hoveredTile;
+  TileCoord? _selectedTile;
   Offset? _hoverPosition;
   Offset? _selectedPosition; // For mobile tooltip positioning
   Size _lastHoverTooltipSize = const Size(320, 240);
@@ -88,7 +85,6 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
 
   void _onTransformChanged() {
     final matrix = _transformationController.value;
-    // Check if transformation is not identity (default state)
     final isTransformed = matrix != Matrix4.identity();
     if (_isCanvasTransformed != isTransformed) {
       setState(() => _isCanvasTransformed = isTransformed);
@@ -120,9 +116,7 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
       _tilemapSnapshotSub = bridge.tilemapStateStream().listen(
         (snap) {
           if (!mounted) return;
-          // Store snapshot for tooltip data access.
           _tilemapSnapshot = snap;
-          // Update scroll overlay rects via ValueNotifier (isolated repaint).
           if (_showScrollOverlay) {
             _scrollOverlayRects.value = _scrollOverlayRectsFromSnapshot(snap);
           }
@@ -187,11 +181,10 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
     }
     final hasRom = ref.watch(nesControllerProvider).romHash != null;
     final loading = !hasRom || _isCreating || _flutterTextureId == null;
-    final base = ViewerSkeletonizer(
+    return ViewerSkeletonizer(
       enabled: loading,
       child: _buildMainLayout(context),
     );
-    return base;
   }
 
   Widget _buildErrorState() {
@@ -240,16 +233,13 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
       );
     }
 
-    // Mobile layout - wrap in GestureDetector to dismiss tooltip on tap outside
     return GestureDetector(
       onTap: _clearSelection,
       behavior: HitTestBehavior.translucent,
       child: Stack(
         children: [
           tilemap,
-          // Settings button (top-right)
           Positioned(top: 12, right: 12, child: _buildSettingsButton(context)),
-          // Reset zoom button (bottom-left, only when transformed)
           if (_isCanvasTransformed)
             Positioned(
               bottom: 12,
@@ -312,10 +302,8 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
   Widget _buildTilemapView(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    // Desktop: show tooltip on hover
     final showHoverTooltip =
         isNativeDesktop && _hoveredTile != null && _tilemapSnapshot != null;
-    // Mobile: show tooltip on tap selection
     final showSelectedTooltip =
         !isNativeDesktop && _selectedTile != null && _tilemapSnapshot != null;
 
@@ -339,7 +327,6 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
                   maxScale: _maxScale,
                   panEnabled: true,
                   scaleEnabled: true,
-                  // Allow panning beyond boundaries when zoomed in
                   boundaryMargin: const EdgeInsets.all(double.infinity),
                   constrained: false,
                   child: SizedBox(
@@ -347,17 +334,15 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
                     height: size.height,
                     child: MouseRegion(
                       onHover: (event) =>
-                          _handleHoverWithTransform(event.localPosition, size),
+                          _handleHover(event.localPosition, size),
                       onExit: (_) => setState(() {
                         _hoveredTile = null;
                         _hoverPosition = null;
                       }),
                       child: GestureDetector(
                         behavior: HitTestBehavior.opaque,
-                        onTapDown: (details) => _handleTapWithTransform(
-                          details.localPosition,
-                          size,
-                        ),
+                        onTapDown: (details) =>
+                            _handleTap(details.localPosition, size),
                         child: Stack(
                           children: [
                             if (_flutterTextureId != null &&
@@ -377,12 +362,11 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
                                   ),
                                 ),
                               ),
-                            // Use ValueListenableBuilder for scroll overlay - isolated repaint
                             ValueListenableBuilder<List<Rect>>(
                               valueListenable: _scrollOverlayRects,
                               builder: (context, scrollRects, _) {
                                 return CustomPaint(
-                                  painter: _TilemapGridPainter(
+                                  painter: TilemapGridPainter(
                                     showTileGrid: _showTileGrid,
                                     showAttributeGrid: _showAttributeGrid,
                                     showAttributeGrid32: _showAttributeGrid32,
@@ -415,24 +399,6 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
     );
   }
 
-  /// Transform local position considering zoom/pan transformation
-  Offset _transformPosition(Offset localPosition) {
-    // The localPosition is already in the transformed (zoomed/panned) space
-    // For InteractiveViewer with constrained: false, localPosition is
-    // already relative to the child content
-    return localPosition;
-  }
-
-  void _handleHoverWithTransform(Offset localPosition, Size size) {
-    final transformedPosition = _transformPosition(localPosition);
-    _handleHover(transformedPosition, size);
-  }
-
-  void _handleTapWithTransform(Offset localPosition, Size size) {
-    final transformedPosition = _transformPosition(localPosition);
-    _handleTap(transformedPosition, size);
-  }
-
   void _handleHover(Offset position, Size size) {
     final tile = _tileAtPosition(position, size);
     if (tile == _hoveredTile && position == _hoverPosition) return;
@@ -450,7 +416,7 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
     });
   }
 
-  _TileCoord? _tileAtPosition(Offset position, Size size) {
+  TileCoord? _tileAtPosition(Offset position, Size size) {
     if (size.width <= 0 || size.height <= 0) return null;
     if (position.dx < 0 ||
         position.dy < 0 ||
@@ -463,7 +429,7 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
     final y = (position.dy / size.height) * _height;
     final tileX = (x / 8).floor().clamp(0, 63);
     final tileY = (y / 8).floor().clamp(0, 59);
-    return _TileCoord(tileX, tileY);
+    return TileCoord(tileX, tileY);
   }
 
   Widget _buildHoverTooltip(BuildContext context, Size size) {
@@ -472,7 +438,7 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
     final pos = _hoverPosition;
     if (tile == null || snap == null || pos == null) return const SizedBox();
 
-    final info = _computeTileInfo(snap, tile);
+    final info = TileInfo.compute(snap, tile);
     if (info == null) return const SizedBox();
 
     const tooltipWidth = 320.0;
@@ -502,21 +468,42 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
           width: tooltipWidth,
           child: KeyedSubtree(
             key: _hoverTooltipKey,
-            child: _buildTileHoverCard(snapshot: snap, info: info),
+            child: Card(
+              clipBehavior: Clip.antiAlias,
+              elevation: 8,
+              child: SingleChildScrollView(
+                physics: const ClampingScrollPhysics(),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      TilePreview(snapshot: snap, info: info),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: DefaultTextStyle(
+                          style: Theme.of(context).textTheme.bodySmall!,
+                          child: TileInfoTable(info: info),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
           ),
         ),
       ),
     );
   }
 
-  /// Tooltip for mobile - shows on tap selection
   Widget _buildSelectedTooltip(BuildContext context, Size size) {
     final tile = _selectedTile;
     final snap = _tilemapSnapshot;
     final pos = _selectedPosition;
     if (tile == null || snap == null || pos == null) return const SizedBox();
 
-    final info = _computeTileInfo(snap, tile);
+    final info = TileInfo.compute(snap, tile);
     if (info == null) return const SizedBox();
 
     const tooltipWidth = 280.0;
@@ -542,7 +529,29 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
         constraints: BoxConstraints(maxHeight: maxAllowedHeight),
         child: SizedBox(
           width: tooltipWidth,
-          child: _buildTileHoverCard(snapshot: snap, info: info),
+          child: Card(
+            clipBehavior: Clip.antiAlias,
+            elevation: 8,
+            child: SingleChildScrollView(
+              physics: const ClampingScrollPhysics(),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TilePreview(snapshot: snap, info: info),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: DefaultTextStyle(
+                        style: Theme.of(context).textTheme.bodySmall!,
+                        child: TileInfoTable(info: info),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -559,414 +568,6 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
       if (size == _lastHoverTooltipSize) return;
       setState(() => _lastHoverTooltipSize = size);
     });
-  }
-
-  Widget _buildTileHoverCard({
-    required bridge.TilemapSnapshot snapshot,
-    required _TileInfo info,
-  }) {
-    return Card(
-      clipBehavior: Clip.antiAlias,
-      elevation: 8,
-      child: SingleChildScrollView(
-        physics: const ClampingScrollPhysics(),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _TilePreview(snapshot: snapshot, info: info),
-              const SizedBox(width: 12),
-              Expanded(
-                child: DefaultTextStyle(
-                  style: Theme.of(context).textTheme.bodySmall!,
-                  child: _TileInfoTable(info: info),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDesktopSidePanel(BuildContext context) {
-    final snap = _tilemapSnapshot;
-    final selected = _selectedTile != null && snap != null
-        ? _computeTileInfo(snap, _selectedTile!)
-        : null;
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Container(
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerLowest,
-        border: Border(
-          left: BorderSide(color: colorScheme.outlineVariant, width: 1),
-        ),
-      ),
-      child: SinglePositionScrollbar(
-        thumbVisibility: true,
-        builder: (context, controller) {
-          return ListView(
-            controller: controller,
-            primary: false,
-            padding: const EdgeInsets.all(12),
-            children: [
-              _sideSection(
-                context,
-                title: l10n.tilemapPanelDisplay,
-                child: Column(
-                  children: [
-                    _displayModeDropdown(context),
-                    const SizedBox(height: 4),
-                    CheckboxListTile(
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.trailing,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.tilemapTileGrid),
-                      value: _showTileGrid,
-                      onChanged: (v) {
-                        setState(() => _showTileGrid = v ?? false);
-                      },
-                    ),
-                    CheckboxListTile(
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.trailing,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.tilemapAttrGrid),
-                      value: _showAttributeGrid,
-                      onChanged: (v) {
-                        setState(() => _showAttributeGrid = v ?? false);
-                      },
-                    ),
-                    CheckboxListTile(
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.trailing,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.tilemapAttrGrid32),
-                      value: _showAttributeGrid32,
-                      onChanged: (v) =>
-                          setState(() => _showAttributeGrid32 = v ?? false),
-                    ),
-                    CheckboxListTile(
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.trailing,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.tilemapNtBounds),
-                      value: _showNametableDelimiters,
-                      onChanged: (v) {
-                        setState(() => _showNametableDelimiters = v ?? false);
-                      },
-                    ),
-                    CheckboxListTile(
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.trailing,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.tilemapScrollOverlay),
-                      value: _showScrollOverlay,
-                      onChanged: (v) =>
-                          setState(() => _showScrollOverlay = v ?? false),
-                    ),
-                  ],
-                ),
-              ),
-              _sideSection(
-                context,
-                title: l10n.tilemapCapture,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    RadioGroup<_TilemapCaptureMode>(
-                      groupValue: _captureMode,
-                      onChanged: (v) {
-                        if (v == null) return;
-                        setState(() => _captureMode = v);
-                        _applyCaptureMode();
-                      },
-                      child: Column(
-                        children: [
-                          RadioListTile<_TilemapCaptureMode>(
-                            dense: true,
-                            visualDensity: VisualDensity.compact,
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(l10n.tilemapCaptureFrameStart),
-                            value: _TilemapCaptureMode.frameStart,
-                          ),
-                          RadioListTile<_TilemapCaptureMode>(
-                            dense: true,
-                            visualDensity: VisualDensity.compact,
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(l10n.tilemapCaptureVblankStart),
-                            value: _TilemapCaptureMode.vblankStart,
-                          ),
-                          RadioListTile<_TilemapCaptureMode>(
-                            dense: true,
-                            visualDensity: VisualDensity.compact,
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(l10n.tilemapCaptureManual),
-                            value: _TilemapCaptureMode.scanline,
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: _numberFieldModern(
-                            label: l10n.tilemapScanline,
-                            enabled:
-                                _captureMode == _TilemapCaptureMode.scanline,
-                            controller: _scanlineController,
-                            hint: '$_minScanline ~ $_maxScanline',
-                            onSubmitted: (v) {
-                              final value = int.tryParse(v);
-                              if (value == null ||
-                                  value < _minScanline ||
-                                  value > _maxScanline) {
-                                return;
-                              }
-                              setState(() => _scanline = value);
-                              _scanlineController.text = _scanline.toString();
-                              _applyCaptureMode();
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: 10),
-                        Expanded(
-                          child: _numberFieldModern(
-                            label: l10n.tilemapDot,
-                            enabled:
-                                _captureMode == _TilemapCaptureMode.scanline,
-                            controller: _dotController,
-                            hint: '$_minDot ~ $_maxDot',
-                            onSubmitted: (v) {
-                              final value = int.tryParse(v);
-                              if (value == null ||
-                                  value < _minDot ||
-                                  value > _maxDot) {
-                                return;
-                              }
-                              setState(() => _dot = value);
-                              _dotController.text = _dot.toString();
-                              _applyCaptureMode();
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              _sideSection(
-                context,
-                title: l10n.tilemapPanelTilemap,
-                child: Column(
-                  children: [
-                    _kvModern(l10n.tilemapInfoSize, '64×60'),
-                    _kvModern(l10n.tilemapInfoSizePx, '512×480'),
-                    _kvModern(l10n.tilemapInfoTilemapAddress, _hex(0x2000)),
-                    _kvModern(
-                      l10n.tilemapInfoTilesetAddress,
-                      snap != null ? _hex(snap.bgPatternBase) : '—',
-                    ),
-                    _kvModern(
-                      l10n.tilemapInfoMirroring,
-                      snap != null
-                          ? _mirroringLabel(l10n, snap.mirroring)
-                          : '—',
-                    ),
-                    _kvModern(
-                      l10n.tilemapInfoTileFormat,
-                      l10n.tilemapInfoTileFormat2bpp,
-                    ),
-                  ],
-                ),
-              ),
-              _sideSection(
-                context,
-                title: l10n.tilemapPanelSelectedTile,
-                child: (selected == null || snap == null)
-                    ? _emptyHint(colorScheme.onSurfaceVariant)
-                    : _TileInfoCard(info: selected, snapshot: snap),
-              ),
-            ],
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _sideSection(
-    BuildContext context, {
-    required String title,
-    required Widget child,
-  }) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Card(
-        elevation: 0,
-        color: colorScheme.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: colorScheme.outlineVariant),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(10),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(height: 10),
-              child,
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _emptyHint(Color color) {
-    return Text('—', style: TextStyle(color: color));
-  }
-
-  Widget _numberFieldModern({
-    required String label,
-    required bool enabled,
-    required TextEditingController controller,
-    required String hint,
-    required ValueChanged<String> onSubmitted,
-  }) {
-    return TextField(
-      enabled: enabled,
-      controller: controller
-        ..selection = TextSelection.fromPosition(
-          TextPosition(offset: controller.text.length),
-        ),
-      decoration: InputDecoration(
-        labelText: label,
-        hintText: hint,
-        isDense: true,
-        filled: true,
-        fillColor: Theme.of(context).colorScheme.surfaceContainerLowest,
-        border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
-      ),
-      keyboardType: TextInputType.number,
-      onSubmitted: onSubmitted,
-    );
-  }
-
-  Widget _kvModern(String k, String v) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(k, style: const TextStyle(color: Colors.black54)),
-          ),
-          Text(v, style: const TextStyle(fontWeight: FontWeight.w600)),
-        ],
-      ),
-    );
-  }
-
-  String _hex(int value, {int width = 4}) {
-    return '\$${value.toRadixString(16).toUpperCase().padLeft(width, '0')}';
-  }
-
-  String _mirroringLabel(AppLocalizations l10n, bridge.TilemapMirroring m) {
-    switch (m) {
-      case bridge.TilemapMirroring.horizontal:
-        return l10n.tilemapMirroringHorizontal;
-      case bridge.TilemapMirroring.vertical:
-        return l10n.tilemapMirroringVertical;
-      case bridge.TilemapMirroring.fourScreen:
-        return l10n.tilemapMirroringFourScreen;
-      case bridge.TilemapMirroring.singleScreenLower:
-        return l10n.tilemapMirroringSingleScreenLower;
-      case bridge.TilemapMirroring.singleScreenUpper:
-        return l10n.tilemapMirroringSingleScreenUpper;
-      case bridge.TilemapMirroring.mapperControlled:
-        return l10n.tilemapMirroringMapperControlled;
-    }
-  }
-
-  _TileInfo? _computeTileInfo(bridge.TilemapSnapshot snap, _TileCoord tile) {
-    final tileX = tile.x;
-    final tileY = tile.y;
-    final ntX = tileX >= 32 ? 1 : 0;
-    final ntY = tileY >= 30 ? 1 : 0;
-    final ntIndex = ntY * 2 + ntX;
-
-    final tileXInNt = tileX % 32;
-    final tileYInNt = tileY % 30;
-
-    final ntLocalAddr = tileYInNt * 32 + tileXInNt;
-    final tilemapAddress = 0x2000 + ntIndex * 0x400 + ntLocalAddr;
-
-    final ciramBase = _mirrorNametableToCiramOffset(ntIndex, snap.mirroring);
-    final tileCiramAddr = ciramBase + ntLocalAddr;
-    if (tileCiramAddr < 0 || tileCiramAddr >= snap.ciram.length) return null;
-
-    final tileIndex = snap.ciram[tileCiramAddr];
-
-    final attrLocalAddr = 0x3C0 + (tileYInNt ~/ 4) * 8 + (tileXInNt ~/ 4);
-    final attrAddress = 0x2000 + ntIndex * 0x400 + attrLocalAddr;
-    final attrCiramAddr = ciramBase + attrLocalAddr;
-    final attrByte = attrCiramAddr >= 0 && attrCiramAddr < snap.ciram.length
-        ? snap.ciram[attrCiramAddr]
-        : 0;
-
-    final shift = ((tileYInNt % 4) ~/ 2) * 4 + ((tileXInNt % 4) ~/ 2) * 2;
-    final paletteIndex = (attrByte >> shift) & 0x03;
-    final paletteAddress = 0x3F00 + paletteIndex * 4;
-
-    final tileAddressPpu = snap.bgPatternBase + tileIndex * 16;
-
-    return _TileInfo(
-      tileX: tileX,
-      tileY: tileY,
-      ntIndex: ntIndex,
-      tileIndex: tileIndex,
-      tilemapAddress: tilemapAddress,
-      tileAddressPpu: tileAddressPpu,
-      paletteIndex: paletteIndex,
-      paletteAddress: paletteAddress,
-      attrAddress: attrAddress,
-      attrByte: attrByte,
-    );
-  }
-
-  int _mirrorNametableToCiramOffset(
-    int ntIndex,
-    bridge.TilemapMirroring mirroring,
-  ) {
-    final physicalNt = switch (mirroring) {
-      bridge.TilemapMirroring.horizontal =>
-        (ntIndex == 0 || ntIndex == 1) ? 0 : 1,
-      bridge.TilemapMirroring.vertical =>
-        (ntIndex == 0 || ntIndex == 2) ? 0 : 1,
-      bridge.TilemapMirroring.fourScreen => ntIndex.clamp(0, 1),
-      bridge.TilemapMirroring.singleScreenLower => 0,
-      bridge.TilemapMirroring.singleScreenUpper => 1,
-      bridge.TilemapMirroring.mapperControlled => ntIndex.clamp(0, 1),
-    };
-    return physicalNt * 0x400;
   }
 
   Widget _buildDesktopSidePanelWrapper(BuildContext context) {
@@ -988,7 +589,53 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
         },
         child: SizedBox(
           width: panelWidth,
-          child: _buildDesktopSidePanel(context),
+          child: TilemapSidePanel(
+            snapshot: _tilemapSnapshot,
+            selectedTile: _selectedTile,
+            showTileGrid: _showTileGrid,
+            showAttributeGrid: _showAttributeGrid,
+            showAttributeGrid32: _showAttributeGrid32,
+            showNametableDelimiters: _showNametableDelimiters,
+            showScrollOverlay: _showScrollOverlay,
+            displayMode: _displayMode,
+            captureMode: _captureMode,
+            scanlineController: _scanlineController,
+            dotController: _dotController,
+            onShowTileGridChanged: (v) =>
+                setState(() => _showTileGrid = v ?? false),
+            onShowAttributeGridChanged: (v) =>
+                setState(() => _showAttributeGrid = v ?? false),
+            onShowAttributeGrid32Changed: (v) =>
+                setState(() => _showAttributeGrid32 = v ?? false),
+            onShowNametableDelimitersChanged: (v) =>
+                setState(() => _showNametableDelimiters = v ?? false),
+            onShowScrollOverlayChanged: (v) =>
+                setState(() => _showScrollOverlay = v ?? false),
+            onDisplayModeChanged: (v) {
+              setState(() => _displayMode = v);
+              _applyTextureRenderMode();
+            },
+            onCaptureModeChanged: (v) {
+              setState(() => _captureMode = v);
+              _applyCaptureMode();
+            },
+            onScanlineSubmitted: (v) {
+              final value = int.tryParse(v);
+              if (value != null && value >= -1 && value <= 260) {
+                setState(() => _scanline = value);
+                _scanlineController.text = _scanline.toString();
+                _applyCaptureMode();
+              }
+            },
+            onDotSubmitted: (v) {
+              final value = int.tryParse(v);
+              if (value != null && value >= 0 && value <= 340) {
+                setState(() => _dot = value);
+                _dotController.text = _dot.toString();
+                _applyCaptureMode();
+              }
+            },
+          ),
         ),
       ),
     );
@@ -1021,7 +668,51 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
         ),
       ),
       tooltip: l10n.tilemapSettings,
-      onPressed: () => _showSettingsDialog(context),
+      onPressed: () {
+        final RenderBox button = context.findRenderObject() as RenderBox;
+        final buttonPosition = button.localToGlobal(Offset.zero);
+        showTilemapSettingsMenu(
+          context: context,
+          buttonPosition: buttonPosition,
+          buttonSize: button.size,
+          displayMode: _displayMode,
+          showTileGrid: _showTileGrid,
+          showAttributeGrid: _showAttributeGrid,
+          showAttributeGrid32: _showAttributeGrid32,
+          showNametableDelimiters: _showNametableDelimiters,
+          showScrollOverlay: _showScrollOverlay,
+          captureMode: _captureMode,
+          scanline: _scanline,
+          dot: _dot,
+          onDisplayModeChanged: (v) {
+            setState(() => _displayMode = v);
+            _applyTextureRenderMode();
+          },
+          onShowTileGridChanged: (v) =>
+              setState(() => _showTileGrid = v ?? false),
+          onShowAttributeGridChanged: (v) =>
+              setState(() => _showAttributeGrid = v ?? false),
+          onShowAttributeGrid32Changed: (v) =>
+              setState(() => _showAttributeGrid32 = v ?? false),
+          onShowNametableDelimitersChanged: (v) =>
+              setState(() => _showNametableDelimiters = v ?? false),
+          onShowScrollOverlayChanged: (v) =>
+              setState(() => _showScrollOverlay = v ?? false),
+          onCaptureModeChanged: (v) {
+            setState(() => _captureMode = v);
+            _applyCaptureMode();
+          },
+          onScanlineDotChanged: (s, d) {
+            setState(() {
+              _scanline = s;
+              _dot = d;
+              _scanlineController.text = _scanline.toString();
+              _dotController.text = _dot.toString();
+            });
+            _applyCaptureMode();
+          },
+        );
+      },
     );
   }
 
@@ -1057,311 +748,22 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
     );
   }
 
-  void _showSettingsDialog(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-
-    // Get button position for menu placement (positioned at top-right)
-    final RenderBox button = context.findRenderObject() as RenderBox;
-    final RenderBox overlay =
-        Overlay.of(context).context.findRenderObject() as RenderBox;
-    final buttonPosition = button.localToGlobal(Offset.zero, ancestor: overlay);
-
-    showMenu<void>(
-      context: context,
-      position: RelativeRect.fromLTRB(
-        buttonPosition.dx +
-            button.size.width -
-            280, // 280px menu width, aligned to button right
-        buttonPosition.dy +
-            button.size.height +
-            4, // Just below button with small gap
-        overlay.size.width -
-            buttonPosition.dx -
-            button.size.width, // Right edge
-        0,
-      ),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      items: [
-        // Overlay section header
-        PopupMenuItem<void>(
-          onTap: null, // Disable interaction but keep text color
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Text(
-            l10n.tilemapOverlay,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
-        PopupMenuItem<void>(
-          enabled: false,
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 6,
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          l10n.tilemapDisplayMode,
-                          style: theme.textTheme.bodySmall,
-                        ),
-                      ),
-                      SizedBox(
-                        width: 180,
-                        child: AnimatedDropdownMenu<_TilemapDisplayMode>(
-                          density: AnimatedDropdownMenuDensity.compact,
-                          value: _displayMode,
-                          entries: [
-                            DropdownMenuEntry(
-                              value: _TilemapDisplayMode.defaultMode,
-                              label: l10n.tilemapDisplayModeDefault,
-                            ),
-                            DropdownMenuEntry(
-                              value: _TilemapDisplayMode.grayscale,
-                              label: l10n.tilemapDisplayModeGrayscale,
-                            ),
-                            DropdownMenuEntry(
-                              value: _TilemapDisplayMode.attributeView,
-                              label: l10n.tilemapDisplayModeAttributeView,
-                            ),
-                          ],
-                          onSelected: (v) {
-                            setState(() => _displayMode = v);
-                            setMenuState(() {});
-                            _applyTextureRenderMode();
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                CheckboxListTile(
-                  dense: true,
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                  title: Text(l10n.tilemapTileGrid),
-                  value: _showTileGrid,
-                  onChanged: (v) {
-                    setState(() => _showTileGrid = v ?? false);
-                    setMenuState(() {});
-                  },
-                ),
-                CheckboxListTile(
-                  dense: true,
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                  title: Text(l10n.tilemapAttrGrid),
-                  value: _showAttributeGrid,
-                  onChanged: (v) {
-                    setState(() => _showAttributeGrid = v ?? false);
-                    setMenuState(() {});
-                  },
-                ),
-                CheckboxListTile(
-                  dense: true,
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                  title: Text(l10n.tilemapAttrGrid32),
-                  value: _showAttributeGrid32,
-                  onChanged: (v) {
-                    setState(() => _showAttributeGrid32 = v ?? false);
-                    setMenuState(() {});
-                  },
-                ),
-                CheckboxListTile(
-                  dense: true,
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                  title: Text(l10n.tilemapNtBounds),
-                  value: _showNametableDelimiters,
-                  onChanged: (v) {
-                    setState(() => _showNametableDelimiters = v ?? false);
-                    setMenuState(() {});
-                  },
-                ),
-                CheckboxListTile(
-                  dense: true,
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                  title: Text(l10n.tilemapScrollOverlay),
-                  value: _showScrollOverlay,
-                  onChanged: (v) {
-                    setState(() => _showScrollOverlay = v ?? false);
-                    setMenuState(() {});
-                  },
-                ),
-              ],
-            ),
-          ),
-        ),
-        const PopupMenuDivider(height: 1),
-        // Capture section header
-        PopupMenuItem<void>(
-          onTap: null, // Disable interaction but keep text color
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Text(
-            l10n.tilemapCapture,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.primary,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
-        PopupMenuItem<void>(
-          onTap: () {}, // Empty tap to prevent closing
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => RadioGroup<_TilemapCaptureMode>(
-              groupValue: _captureMode,
-              onChanged: (v) {
-                if (v == null) return;
-                setState(() => _captureMode = v);
-                setMenuState(() {});
-                _applyCaptureMode();
-              },
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  RadioListTile<_TilemapCaptureMode>(
-                    dense: true,
-                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                    title: Text(l10n.tilemapCaptureFrameStart),
-                    value: _TilemapCaptureMode.frameStart,
-                  ),
-                  RadioListTile<_TilemapCaptureMode>(
-                    dense: true,
-                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                    title: Text(l10n.tilemapCaptureVblankStart),
-                    value: _TilemapCaptureMode.vblankStart,
-                  ),
-                  RadioListTile<_TilemapCaptureMode>(
-                    dense: true,
-                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-                    title: Text(l10n.tilemapCaptureManual),
-                    value: _TilemapCaptureMode.scanline,
-                  ),
-                  if (_captureMode == _TilemapCaptureMode.scanline) ...[
-                    const PopupMenuDivider(height: 1),
-                    PopupMenuItem<void>(
-                      onTap: () {}, // Prevent closing
-                      padding: EdgeInsets.zero,
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: _buildScanlineControlsForDialog(
-                          theme,
-                          l10n,
-                          setMenuState,
-                        ),
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildScanlineControlsForDialog(
-    ThemeData theme,
-    AppLocalizations l10n,
-    StateSetter setDialogState,
-  ) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // Scanline input
-        Text('${l10n.tilemapScanline}:', style: theme.textTheme.bodySmall),
-        const SizedBox(height: 4),
-        TextField(
-          controller: TextEditingController(text: _scanline.toString())
-            ..selection = TextSelection.fromPosition(
-              TextPosition(offset: _scanline.toString().length),
-            ),
-          decoration: InputDecoration(
-            isDense: true,
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: 12,
-              vertical: 8,
-            ),
-            border: const OutlineInputBorder(),
-            hintText: '$_minScanline ~ $_maxScanline',
-          ),
-          keyboardType: TextInputType.number,
-          onSubmitted: (v) {
-            final value = int.tryParse(v);
-            if (value != null &&
-                value >= _minScanline &&
-                value <= _maxScanline) {
-              setState(() {
-                _scanline = value;
-                _scanlineController.text = _scanline.toString();
-              });
-              setDialogState(() {});
-              _applyCaptureMode();
-            }
-          },
-        ),
-        const SizedBox(height: 12),
-        // Dot input
-        Text('${l10n.tilemapDot}:', style: theme.textTheme.bodySmall),
-        const SizedBox(height: 4),
-        TextField(
-          controller: TextEditingController(text: _dot.toString())
-            ..selection = TextSelection.fromPosition(
-              TextPosition(offset: _dot.toString().length),
-            ),
-          decoration: InputDecoration(
-            isDense: true,
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: 12,
-              vertical: 8,
-            ),
-            border: const OutlineInputBorder(),
-            hintText: '$_minDot ~ $_maxDot',
-          ),
-          keyboardType: TextInputType.number,
-          onSubmitted: (v) {
-            final value = int.tryParse(v);
-            if (value != null && value >= _minDot && value <= _maxDot) {
-              setState(() {
-                _dot = value;
-                _dotController.text = _dot.toString();
-              });
-              setDialogState(() {});
-              _applyCaptureMode();
-            }
-          },
-        ),
-      ],
-    );
-  }
-
   Future<void> _applyCaptureMode() async {
     switch (_captureMode) {
-      case _TilemapCaptureMode.frameStart:
+      case TilemapCaptureMode.frameStart:
         await bridge.setTilemapCaptureFrameStart();
-      case _TilemapCaptureMode.vblankStart:
+      case TilemapCaptureMode.vblankStart:
         await bridge.setTilemapCaptureVblankStart();
-      case _TilemapCaptureMode.scanline:
+      case TilemapCaptureMode.scanline:
         await bridge.setTilemapCaptureScanline(scanline: _scanline, dot: _dot);
     }
   }
 
   Future<void> _applyTextureRenderMode() async {
     final (showTileGrid, showAttributeGrid) = switch (_displayMode) {
-      _TilemapDisplayMode.defaultMode => (false, false),
-      _TilemapDisplayMode.grayscale => (true, false),
-      _TilemapDisplayMode.attributeView => (false, true),
+      TilemapDisplayMode.defaultMode => (false, false),
+      TilemapDisplayMode.grayscale => (true, false),
+      TilemapDisplayMode.attributeView => (false, true),
     };
     final mode = showAttributeGrid
         ? 2
@@ -1371,50 +773,7 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
     await bridge.setTilemapDisplayMode(mode: mode);
   }
 
-  Widget _displayModeDropdown(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-
-    return Row(
-      children: [
-        Expanded(
-          child: Text(
-            l10n.tilemapDisplayMode,
-            style: theme.textTheme.bodySmall,
-          ),
-        ),
-        SizedBox(
-          width: 180,
-          child: AnimatedDropdownMenu<_TilemapDisplayMode>(
-            density: AnimatedDropdownMenuDensity.compact,
-            value: _displayMode,
-            entries: [
-              DropdownMenuEntry(
-                value: _TilemapDisplayMode.defaultMode,
-                label: l10n.tilemapDisplayModeDefault,
-              ),
-              DropdownMenuEntry(
-                value: _TilemapDisplayMode.grayscale,
-                label: l10n.tilemapDisplayModeGrayscale,
-              ),
-              DropdownMenuEntry(
-                value: _TilemapDisplayMode.attributeView,
-                label: l10n.tilemapDisplayModeAttributeView,
-              ),
-            ],
-            onSelected: (v) {
-              setState(() => _displayMode = v);
-              _applyTextureRenderMode();
-            },
-          ),
-        ),
-      ],
-    );
-  }
-
   List<Rect> _scrollOverlayRectsFromSnapshot(bridge.TilemapSnapshot snap) {
-    // Use the PPU `t` (temp) address for scroll origin. The `v` address
-    // is advanced by background fetches/pipeline and is not stable for viewport math.
     final v = snap.tempAddr & 0x7FFF;
     final fineX = snap.fineX & 0x07;
     final coarseX = v & 0x1F;
@@ -1470,537 +829,5 @@ class _TilemapViewerState extends ConsumerState<TilemapViewer> {
       }
     }
     return rects;
-  }
-}
-
-enum _TilemapCaptureMode { frameStart, vblankStart, scanline }
-
-@immutable
-class _TileCoord {
-  const _TileCoord(this.x, this.y);
-
-  final int x;
-  final int y;
-
-  @override
-  bool operator ==(Object other) =>
-      other is _TileCoord && other.x == x && other.y == y;
-
-  @override
-  int get hashCode => Object.hash(x, y);
-}
-
-@immutable
-class _TileInfo {
-  const _TileInfo({
-    required this.tileX,
-    required this.tileY,
-    required this.ntIndex,
-    required this.tileIndex,
-    required this.tilemapAddress,
-    required this.tileAddressPpu,
-    required this.paletteIndex,
-    required this.paletteAddress,
-    required this.attrAddress,
-    required this.attrByte,
-  });
-
-  final int tileX;
-  final int tileY;
-  final int ntIndex;
-  final int tileIndex;
-  final int tilemapAddress;
-  final int tileAddressPpu;
-  final int paletteIndex;
-  final int paletteAddress;
-  final int attrAddress;
-  final int attrByte;
-}
-
-class _TilePreview extends StatelessWidget {
-  const _TilePreview({required this.snapshot, required this.info});
-
-  final bridge.TilemapSnapshot snapshot;
-  final _TileInfo info;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SizedBox(
-          width: 64,
-          height: 64,
-          child: CustomPaint(
-            painter: _TilePreviewPainter(snapshot: snapshot, info: info),
-          ),
-        ),
-        const SizedBox(height: 8),
-        _PaletteStrip(snapshot: snapshot, info: info),
-      ],
-    );
-  }
-}
-
-class _TilePreviewPainter extends CustomPainter {
-  _TilePreviewPainter({required this.snapshot, required this.info});
-
-  final bridge.TilemapSnapshot snapshot;
-  final _TileInfo info;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final sx = size.width / 8;
-    final sy = size.height / 8;
-    final paint = Paint();
-
-    final base = snapshot.bgPatternBase + info.tileIndex * 16;
-    for (var py = 0; py < 8; py++) {
-      final o = base + py;
-      if (o + 8 >= snapshot.chr.length) break;
-      final plane0 = snapshot.chr[o];
-      final plane1 = snapshot.chr[o + 8];
-      for (var px = 0; px < 8; px++) {
-        final bit = 7 - px;
-        final lo = (plane0 >> bit) & 1;
-        final hi = (plane1 >> bit) & 1;
-        final colorIndex = (hi << 1) | lo;
-        final nesColor = _nesColorIndex(
-          snapshot,
-          paletteIndex: info.paletteIndex,
-          colorIndex: colorIndex,
-        );
-        paint.color = _colorFromNes(snapshot.rgbaPalette, nesColor);
-        canvas.drawRect(Rect.fromLTWH(px * sx, py * sy, sx, sy), paint);
-      }
-    }
-  }
-
-  int _nesColorIndex(
-    bridge.TilemapSnapshot snap, {
-    required int paletteIndex,
-    required int colorIndex,
-  }) {
-    final pal = snap.palette;
-    if (pal.isEmpty) return 0;
-    if (colorIndex == 0) return pal[0] & 0x3F;
-    final idx = paletteIndex * 4 + colorIndex;
-    if (idx < 0 || idx >= pal.length) return 0;
-    return pal[idx] & 0x3F;
-  }
-
-  Color _colorFromNes(Uint8List rgbaPalette, int nesColor) {
-    final base = (nesColor & 0x3F) * 4;
-    if (base + 3 >= rgbaPalette.length) return const Color(0xFF000000);
-    final r = rgbaPalette[base];
-    final g = rgbaPalette[base + 1];
-    final b = rgbaPalette[base + 2];
-    final a = rgbaPalette[base + 3];
-    return Color.fromARGB(a, r, g, b);
-  }
-
-  @override
-  bool shouldRepaint(_TilePreviewPainter oldDelegate) {
-    return snapshot != oldDelegate.snapshot || info != oldDelegate.info;
-  }
-}
-
-class _PaletteStrip extends StatelessWidget {
-  const _PaletteStrip({required this.snapshot, required this.info});
-
-  final bridge.TilemapSnapshot snapshot;
-  final _TileInfo info;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = List<Color>.generate(4, (i) {
-      int nes;
-      if (snapshot.palette.isEmpty) {
-        nes = 0;
-      } else if (i == 0) {
-        nes = snapshot.palette[0];
-      } else {
-        final idx = info.paletteIndex * 4 + i;
-        nes = snapshot.palette[idx.clamp(0, snapshot.palette.length - 1)];
-      }
-
-      final base = (nes & 0x3F) * 4;
-      if (base + 3 >= snapshot.rgbaPalette.length) {
-        return const Color(0xFF000000);
-      }
-      return Color.fromARGB(
-        snapshot.rgbaPalette[base + 3],
-        snapshot.rgbaPalette[base],
-        snapshot.rgbaPalette[base + 1],
-        snapshot.rgbaPalette[base + 2],
-      );
-    });
-
-    return Row(
-      children: [
-        for (final c in colors)
-          Container(
-            width: 16,
-            height: 16,
-            margin: const EdgeInsets.only(right: 4),
-            decoration: BoxDecoration(
-              color: c,
-              border: Border.all(color: Colors.black26),
-            ),
-          ),
-      ],
-    );
-  }
-}
-
-class _TileInfoTable extends StatelessWidget {
-  const _TileInfoTable({required this.info});
-
-  final _TileInfo info;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    String hex(int v, {int width = 4}) =>
-        '\$${v.toRadixString(16).toUpperCase().padLeft(width, '0')}';
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _row(l10n.tilemapLabelColumnRow, '${info.tileX}, ${info.tileY}'),
-        _row(l10n.tilemapLabelXY, '${info.tileX * 8}, ${info.tileY * 8}'),
-        _row(l10n.tilemapLabelSize, '8×8'),
-        const Divider(height: 16),
-        _row(l10n.tilemapLabelTilemapAddress, hex(info.tilemapAddress)),
-        _row(l10n.tilemapLabelTileIndex, hex(info.tileIndex, width: 2)),
-        _row(l10n.tilemapLabelTileAddressPpu, hex(info.tileAddressPpu)),
-        const Divider(height: 16),
-        _row(l10n.tilemapLabelPaletteIndex, '${info.paletteIndex}'),
-        _row(l10n.tilemapLabelPaletteAddress, hex(info.paletteAddress)),
-        const Divider(height: 16),
-        _row(l10n.tilemapLabelAttributeAddress, hex(info.attrAddress)),
-        _row(l10n.tilemapLabelAttributeData, hex(info.attrByte, width: 2)),
-      ],
-    );
-  }
-
-  Widget _row(String k, String v) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 1),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(k, style: const TextStyle(color: Colors.black54)),
-          ),
-          Text(v),
-        ],
-      ),
-    );
-  }
-}
-
-class _TileInfoCard extends StatelessWidget {
-  const _TileInfoCard({required this.info, required this.snapshot});
-
-  final _TileInfo info;
-  final bridge.TilemapSnapshot snapshot;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final labelStyle = theme.textTheme.bodySmall?.copyWith(
-      color: colorScheme.onSurfaceVariant,
-    );
-    final valueStyle = theme.textTheme.bodySmall?.copyWith(
-      fontWeight: FontWeight.w600,
-    );
-
-    String hex(int v, {int width = 4}) =>
-        '\$${v.toRadixString(16).toUpperCase().padLeft(width, '0')}';
-
-    Widget kv(String label, String value) {
-      return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Row(
-          children: [
-            Expanded(child: Text(label, style: labelStyle)),
-            Text(value, style: valueStyle),
-          ],
-        ),
-      );
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SizedBox(
-              width: 84,
-              child: _TilePreview(snapshot: snapshot, info: info),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                children: [
-                  _metaRow(
-                    label: l10n.tilemapLabelColumnRow,
-                    value: '${info.tileX}, ${info.tileY}',
-                    labelStyle: labelStyle,
-                    valueStyle: valueStyle,
-                  ),
-                  _metaRow(
-                    label: l10n.tilemapLabelXY,
-                    value: '${info.tileX * 8}, ${info.tileY * 8}',
-                    labelStyle: labelStyle,
-                    valueStyle: valueStyle,
-                  ),
-                  _metaRow(
-                    label: l10n.tilemapLabelSize,
-                    value: '8×8',
-                    labelStyle: labelStyle,
-                    valueStyle: valueStyle,
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 10),
-        const Divider(height: 1),
-        const SizedBox(height: 10),
-        kv(l10n.tilemapSelectedTileTilemap, hex(info.tilemapAddress)),
-        kv(l10n.tilemapSelectedTileTileIdx, hex(info.tileIndex, width: 2)),
-        kv(l10n.tilemapSelectedTileTilePpu, hex(info.tileAddressPpu)),
-        kv(
-          l10n.tilemapSelectedTilePalette,
-          '${info.paletteIndex}  ${hex(info.paletteAddress)}',
-        ),
-        kv(
-          l10n.tilemapSelectedTileAttr,
-          '${hex(info.attrAddress)}  ${hex(info.attrByte, width: 2)}',
-        ),
-      ],
-    );
-  }
-
-  Widget _metaRow({
-    required String label,
-    required String value,
-    required TextStyle? labelStyle,
-    required TextStyle? valueStyle,
-  }) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 3),
-      child: Row(
-        children: [
-          Expanded(child: Text(label, style: labelStyle)),
-          Text(value, style: valueStyle),
-        ],
-      ),
-    );
-  }
-}
-
-/// CustomPainter for drawing grid overlays on tilemap texture.
-/// Uses vector graphics for resolution-independent sharp rendering.
-class _TilemapGridPainter extends CustomPainter {
-  final bool showTileGrid;
-  final bool showAttributeGrid;
-  final bool showAttributeGrid32;
-  final bool showNametableDelimiters;
-  final bool showScrollOverlay;
-  final List<Rect> scrollOverlayRects;
-  final _TileCoord? hoveredTile;
-  final _TileCoord? selectedTile;
-
-  _TilemapGridPainter({
-    required this.showTileGrid,
-    required this.showAttributeGrid,
-    required this.showAttributeGrid32,
-    required this.showNametableDelimiters,
-    required this.showScrollOverlay,
-    required this.scrollOverlayRects,
-    required this.hoveredTile,
-    required this.selectedTile,
-  });
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    // Tilemap is 512x480 (2x2 nametables of 256x240 each)
-    const logicalWidth = 512.0;
-    const logicalHeight = 480.0;
-
-    // Calculate scaling factor
-    final scaleX = size.width / logicalWidth;
-    final scaleY = size.height / logicalHeight;
-
-    // Draw 8×8 tile grid
-    if (showTileGrid) {
-      final paint = Paint()
-        ..color = Colors.white.withValues(alpha: 0.5)
-        ..strokeWidth =
-            1.0 // Clear 1px lines
-        ..style = PaintingStyle.stroke;
-
-      for (var y = 0; y <= logicalHeight; y += 8) {
-        final scaledY = y * scaleY;
-        canvas.drawLine(Offset(0, scaledY), Offset(size.width, scaledY), paint);
-      }
-      for (var x = 0; x <= logicalWidth; x += 8) {
-        final scaledX = x * scaleX;
-        canvas.drawLine(
-          Offset(scaledX, 0),
-          Offset(scaledX, size.height),
-          paint,
-        );
-      }
-    }
-
-    // Draw 16×16 attribute grid
-    if (showAttributeGrid) {
-      final paint = Paint()
-        ..color = Colors.cyan
-            .withValues(alpha: 0.7) // Increased visibility
-        ..strokeWidth =
-            0.8 // Increased from 0.6
-        ..style = PaintingStyle.stroke;
-
-      for (var y = 0; y <= logicalHeight; y += 16) {
-        final scaledY = y * scaleY;
-        canvas.drawLine(Offset(0, scaledY), Offset(size.width, scaledY), paint);
-      }
-      for (var x = 0; x <= logicalWidth; x += 16) {
-        final scaledX = x * scaleX;
-        canvas.drawLine(
-          Offset(scaledX, 0),
-          Offset(scaledX, size.height),
-          paint,
-        );
-      }
-    }
-
-    // Draw 32×32 attribute grid (attribute bytes boundaries)
-    if (showAttributeGrid32) {
-      final paint = Paint()
-        ..color = Colors.orange.withValues(alpha: 0.55)
-        ..strokeWidth = 1.0
-        ..style = PaintingStyle.stroke;
-
-      for (var y = 0; y <= logicalHeight; y += 32) {
-        final scaledY = y * scaleY;
-        canvas.drawLine(Offset(0, scaledY), Offset(size.width, scaledY), paint);
-      }
-      for (var x = 0; x <= logicalWidth; x += 32) {
-        final scaledX = x * scaleX;
-        canvas.drawLine(
-          Offset(scaledX, 0),
-          Offset(scaledX, size.height),
-          paint,
-        );
-      }
-    }
-
-    // Draw nametable delimiters (256×240 boundaries)
-    if (showNametableDelimiters) {
-      final paint = Paint()
-        ..color = Colors.white.withValues(alpha: 0.9)
-        ..strokeWidth =
-            1.0 // Crisp single-pixel line
-        ..style = PaintingStyle.stroke;
-
-      // Vertical delimiter at x=256
-      final verticalX = 256.0 * scaleX;
-      canvas.drawLine(
-        Offset(verticalX, 0),
-        Offset(verticalX, size.height),
-        paint,
-      );
-
-      // Horizontal delimiter at y=240
-      final horizontalY = 240.0 * scaleY;
-      canvas.drawLine(
-        Offset(0, horizontalY),
-        Offset(size.width, horizontalY),
-        paint,
-      );
-    }
-
-    if (showScrollOverlay && scrollOverlayRects.isNotEmpty) {
-      final outline = Paint()
-        ..color = Colors.pinkAccent.withValues(alpha: 0.9)
-        ..strokeWidth = 2.0
-        ..style = PaintingStyle.stroke;
-      final fill = Paint()
-        ..color = Colors.pinkAccent.withValues(alpha: 0.12)
-        ..style = PaintingStyle.fill;
-
-      for (final r in scrollOverlayRects) {
-        final scaled = Rect.fromLTWH(
-          r.left * scaleX,
-          r.top * scaleY,
-          r.width * scaleX,
-          r.height * scaleY,
-        );
-        canvas.drawRect(scaled, fill);
-        canvas.drawRect(scaled, outline);
-      }
-    }
-
-    // Hovered tile outline
-    if (hoveredTile != null) {
-      final paint = Paint()
-        ..color = Colors.white.withValues(alpha: 0.9)
-        ..strokeWidth = 2.0
-        ..style = PaintingStyle.stroke;
-
-      final rect = Rect.fromLTWH(
-        hoveredTile!.x * 8.0 * scaleX,
-        hoveredTile!.y * 8.0 * scaleY,
-        8.0 * scaleX,
-        8.0 * scaleY,
-      );
-      canvas.drawRect(rect, paint);
-    }
-
-    // Selected tile outline
-    if (selectedTile != null) {
-      final paint = Paint()
-        ..color = Colors.yellow.withValues(alpha: 0.95)
-        ..strokeWidth = 2.5
-        ..style = PaintingStyle.stroke;
-
-      final rect = Rect.fromLTWH(
-        selectedTile!.x * 8.0 * scaleX,
-        selectedTile!.y * 8.0 * scaleY,
-        8.0 * scaleX,
-        8.0 * scaleY,
-      );
-      canvas.drawRect(rect, paint);
-    }
-  }
-
-  @override
-  bool shouldRepaint(_TilemapGridPainter oldDelegate) {
-    return showTileGrid != oldDelegate.showTileGrid ||
-        showAttributeGrid != oldDelegate.showAttributeGrid ||
-        showAttributeGrid32 != oldDelegate.showAttributeGrid32 ||
-        hoveredTile != oldDelegate.hoveredTile ||
-        selectedTile != oldDelegate.selectedTile ||
-        showNametableDelimiters != oldDelegate.showNametableDelimiters ||
-        showScrollOverlay != oldDelegate.showScrollOverlay ||
-        !_rectListEquals(scrollOverlayRects, oldDelegate.scrollOverlayRects);
-  }
-
-  bool _rectListEquals(List<Rect> a, List<Rect> b) {
-    if (identical(a, b)) return true;
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i] != b[i]) return false;
-    }
-    return true;
   }
 }


### PR DESCRIPTION
- Extract models and enums to tilemap_models.dart
- Extract CustomPainters to tilemap_painters.dart
- Extract helper widgets to tilemap_widgets.dart
- Extract Side Panel and Settings Dialog to dedicated files
- Reduce tilemap_viewer.dart size from ~2000 to ~800 lines