### PR TITLE
refactor(debugger): split tile viewer into focused widgets

### DIFF
--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_info_widgets.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_info_widgets.dart
@@ -1,0 +1,359 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/bridge/api/events.dart' as bridge;
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_geometry.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+
+/// CHR tile preview showing zoomed 8x8 tile with palette colors.
+class ChrTilePreview extends StatelessWidget {
+  const ChrTilePreview({required this.snapshot, required this.info, super.key});
+
+  final bridge.TileSnapshot snapshot;
+  final TileInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 64,
+          height: 64,
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: CustomPaint(
+            painter: _ChrTilePreviewPainter(snapshot: snapshot, info: info),
+          ),
+        ),
+        const SizedBox(height: 8),
+        _PaletteStrip(snapshot: snapshot),
+      ],
+    );
+  }
+}
+
+class _ChrTilePreviewPainter extends CustomPainter {
+  _ChrTilePreviewPainter({required this.snapshot, required this.info});
+
+  final bridge.TileSnapshot snapshot;
+  final TileInfo info;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint();
+    final paletteIndex = snapshot.selectedPalette.clamp(0, 7);
+    final palBase = paletteIndex < 4
+        ? paletteIndex * 4
+        : 0x10 + (paletteIndex - 4) * 4;
+
+    final cellW = size.width / 2;
+    final cellH = size.height / 2;
+
+    for (var i = 0; i < 4; i++) {
+      final pal = snapshot.palette;
+      final idx = i == 0 ? 0 : palBase + i;
+      final nesColor = (idx < pal.length ? pal[idx] : 0) & 0x3F;
+      paint.color = _colorFromNes(nesColor);
+
+      final x = (i % 2) * cellW;
+      final y = (i ~/ 2) * cellH;
+      canvas.drawRect(Rect.fromLTWH(x, y, cellW, cellH), paint);
+    }
+
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: tileViewerHex(info.tileIndexInTable, width: 2),
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: size.width / 4,
+          fontFamily: 'monospace',
+          fontWeight: FontWeight.bold,
+          shadows: const [Shadow(blurRadius: 2, color: Colors.black)],
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    textPainter.paint(
+      canvas,
+      Offset(
+        (size.width - textPainter.width) / 2,
+        (size.height - textPainter.height) / 2,
+      ),
+    );
+  }
+
+  Color _colorFromNes(int nesColor) {
+    final rgba = snapshot.rgbaPalette;
+    final base = (nesColor & 0x3F) * 4;
+    if (base + 3 >= rgba.length) return Colors.black;
+    return Color.fromARGB(
+      rgba[base + 3],
+      rgba[base],
+      rgba[base + 1],
+      rgba[base + 2],
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _ChrTilePreviewPainter old) =>
+      info.tileIndex != old.info.tileIndex ||
+      snapshot.selectedPalette != old.snapshot.selectedPalette;
+}
+
+class _PaletteStrip extends StatelessWidget {
+  const _PaletteStrip({required this.snapshot});
+
+  final bridge.TileSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final paletteIndex = snapshot.selectedPalette.clamp(0, 7);
+    final palBase = paletteIndex < 4
+        ? paletteIndex * 4
+        : 0x10 + (paletteIndex - 4) * 4;
+
+    return Row(
+      children: List.generate(4, (i) {
+        final pal = snapshot.palette;
+        final idx = palBase + i;
+        final nesColor =
+            (i == 0
+                ? (pal.isNotEmpty ? pal[0] : 0)
+                : (idx < pal.length ? pal[idx] : 0)) &
+            0x3F;
+        final rgba = snapshot.rgbaPalette;
+        final base = nesColor * 4;
+        final color = base + 3 < rgba.length
+            ? Color.fromARGB(
+                rgba[base + 3],
+                rgba[base],
+                rgba[base + 1],
+                rgba[base + 2],
+              )
+            : Colors.black;
+
+        return Container(width: 16, height: 8, color: color);
+      }),
+    );
+  }
+}
+
+class TileInfoTable extends StatelessWidget {
+  const TileInfoTable({required this.info, super.key});
+
+  final TileInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final labelStyle = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    final valueStyle = theme.textTheme.bodySmall?.copyWith(
+      fontWeight: FontWeight.w600,
+      fontFamily: 'monospace',
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _kv(
+          l10n.tileViewerPatternTable,
+          '${info.patternTable}',
+          labelStyle,
+          valueStyle,
+        ),
+        _kv(
+          l10n.tileViewerTileIndex,
+          tileViewerHex(info.tileIndexInTable, width: 2),
+          labelStyle,
+          valueStyle,
+        ),
+        _kv(
+          l10n.tileViewerChrAddress,
+          tileViewerHex(info.chrAddress),
+          labelStyle,
+          valueStyle,
+        ),
+      ],
+    );
+  }
+
+  Widget _kv(
+    String label,
+    String value,
+    TextStyle? labelStyle,
+    TextStyle? valueStyle,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: labelStyle),
+          Text(value, style: valueStyle),
+        ],
+      ),
+    );
+  }
+}
+
+class TileInfoCard extends StatelessWidget {
+  const TileInfoCard({required this.tile, required this.snapshot, super.key});
+
+  final TileCoord tile;
+  final bridge.TileSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final info = computeTileInfo(tile);
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+    final labelStyle = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    final valueStyle = theme.textTheme.bodySmall?.copyWith(
+      fontWeight: FontWeight.w600,
+      fontFamily: 'monospace',
+    );
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 76,
+          child: ChrTilePreview(snapshot: snapshot, info: info),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            children: [
+              _infoRow(
+                l10n.tileViewerPatternTable,
+                '${info.patternTable}',
+                labelStyle,
+                valueStyle,
+              ),
+              _infoRow(
+                l10n.tileViewerTileIndex,
+                tileViewerHex(info.tileIndexInTable, width: 2),
+                labelStyle,
+                valueStyle,
+              ),
+              _infoRow(
+                l10n.tileViewerChrAddress,
+                tileViewerHex(info.chrAddress),
+                labelStyle,
+                valueStyle,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _infoRow(
+    String label,
+    String value,
+    TextStyle? labelStyle,
+    TextStyle? valueStyle,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: labelStyle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(value, style: valueStyle),
+        ],
+      ),
+    );
+  }
+}
+
+class TileHoverTooltip extends StatelessWidget {
+  const TileHoverTooltip({
+    required this.tile,
+    required this.snapshot,
+    required this.position,
+    required this.viewportSize,
+    super.key,
+  });
+
+  final TileCoord tile;
+  final bridge.TileSnapshot snapshot;
+  final Offset position;
+  final Size viewportSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final info = computeTileInfo(tile);
+    const tooltipWidth = 220.0;
+    const tooltipHeight = 130.0;
+    const cursorOffset = 16.0;
+
+    final preferRight = position.dx < viewportSize.width * 0.55;
+    final preferDown = position.dy < viewportSize.height * 0.5;
+    final dxCandidate = preferRight
+        ? position.dx + cursorOffset
+        : position.dx - tooltipWidth - cursorOffset;
+    final dyCandidate = preferDown
+        ? position.dy + cursorOffset
+        : position.dy - tooltipHeight - cursorOffset;
+
+    final dx = dxCandidate.clamp(8.0, viewportSize.width - tooltipWidth - 8.0);
+    final dy = dyCandidate.clamp(
+      8.0,
+      viewportSize.height - tooltipHeight - 8.0,
+    );
+
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Positioned(
+      left: dx,
+      top: dy,
+      child: SizedBox(
+        width: tooltipWidth,
+        child: Card(
+          elevation: 4,
+          shadowColor: colorScheme.shadow.withValues(alpha: 0.3),
+          color: colorScheme.surfaceContainerHigh,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: colorScheme.outlineVariant),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ChrTilePreview(snapshot: snapshot, info: info),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: DefaultTextStyle(
+                    style: theme.textTheme.bodySmall!,
+                    child: TileInfoTable(info: info),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_preset_buttons.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_preset_buttons.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+
+class TilePresetButtons extends StatelessWidget {
+  const TilePresetButtons({
+    required this.presets,
+    required this.selectedPreset,
+    required this.onSelected,
+    this.onChanged,
+    super.key,
+  });
+
+  final List<TilePreset> presets;
+  final TilePreset? selectedPreset;
+  final ValueChanged<TilePreset> onSelected;
+  final VoidCallback? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    String presetLabel(TilePreset preset) => switch (preset) {
+      TilePreset.ppu => l10n.tileViewerPresetPpu,
+      TilePreset.chr => l10n.tileViewerPresetChr,
+      TilePreset.rom => l10n.tileViewerPresetRom,
+      TilePreset.bg => l10n.tileViewerPresetBg,
+      TilePreset.oam => l10n.tileViewerPresetOam,
+    };
+
+    return Wrap(
+      spacing: 4,
+      runSpacing: 4,
+      children: presets.map((preset) {
+        final isSelected = selectedPreset == preset;
+        return FilterChip(
+          label: Text(presetLabel(preset)),
+          selected: isSelected,
+          onSelected: (_) {
+            onSelected(preset);
+            onChanged?.call();
+          },
+          showCheckmark: false,
+          visualDensity: VisualDensity.compact,
+          labelPadding: const EdgeInsets.symmetric(horizontal: 4),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_canvas.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_canvas.dart
@@ -1,0 +1,154 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_painters.dart';
+import 'package:nesium_flutter/features/debugger/viewer_skeletonizer.dart';
+
+class TileViewerCanvas extends StatelessWidget {
+  const TileViewerCanvas({
+    required this.textureId,
+    required this.textureWidth,
+    required this.textureHeight,
+    required this.transformationController,
+    required this.minScale,
+    required this.maxScale,
+    required this.showTileGrid,
+    required this.hoveredTile,
+    required this.selectedTile,
+    required this.onHover,
+    required this.onTap,
+    required this.onHoverExit,
+    super.key,
+  });
+
+  final int? textureId;
+  final int textureWidth;
+  final int textureHeight;
+  final TransformationController transformationController;
+  final double minScale;
+  final double maxScale;
+  final bool showTileGrid;
+  final TileCoord? hoveredTile;
+  final TileCoord? selectedTile;
+  final void Function({
+    required Offset position,
+    required Offset contentOffset,
+    required Size contentSize,
+  })
+  onHover;
+  final void Function({
+    required Offset position,
+    required Offset contentOffset,
+    required Size contentSize,
+  })
+  onTap;
+  final VoidCallback onHoverExit;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      color: colorScheme.surfaceContainerLowest,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: colorScheme.outlineVariant),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final viewportSize = constraints.biggest;
+            if (viewportSize.width <= 0 || viewportSize.height <= 0) {
+              return const SizedBox();
+            }
+
+            final scale = math.min(
+              viewportSize.width / textureWidth,
+              viewportSize.height / textureHeight,
+            );
+            final contentSize = Size(
+              textureWidth * scale,
+              textureHeight * scale,
+            );
+            final contentOffset = Offset(
+              (viewportSize.width - contentSize.width) / 2,
+              (viewportSize.height - contentSize.height) / 2,
+            );
+
+            return MouseRegion(
+              onHover: (event) => onHover(
+                position: event.localPosition,
+                contentOffset: contentOffset,
+                contentSize: contentSize,
+              ),
+              onExit: (_) => onHoverExit(),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTapDown: (details) => onTap(
+                  position: details.localPosition,
+                  contentOffset: contentOffset,
+                  contentSize: contentSize,
+                ),
+                child: InteractiveViewer(
+                  transformationController: transformationController,
+                  minScale: minScale,
+                  maxScale: maxScale,
+                  panEnabled: true,
+                  scaleEnabled: true,
+                  boundaryMargin: const EdgeInsets.all(double.infinity),
+                  constrained: false,
+                  child: SizedBox(
+                    width: viewportSize.width,
+                    height: viewportSize.height,
+                    child: Stack(
+                      children: [
+                        Positioned(
+                          left: contentOffset.dx,
+                          top: contentOffset.dy,
+                          width: contentSize.width,
+                          height: contentSize.height,
+                          child: Stack(
+                            fit: StackFit.expand,
+                            children: [
+                              if (textureId != null &&
+                                  !ViewerSkeletonScope.enabledOf(context))
+                                Texture(
+                                  textureId: textureId!,
+                                  filterQuality: FilterQuality.none,
+                                )
+                              else
+                                DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: colorScheme.surfaceContainerHighest,
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                ),
+                              if (showTileGrid)
+                                CustomPaint(painter: TileGridPainter()),
+                              if (hoveredTile != null || selectedTile != null)
+                                CustomPaint(
+                                  painter: TileHighlightPainter(
+                                    hoveredTile: hoveredTile,
+                                    selectedTile: selectedTile,
+                                    tileWidth: contentSize.width / 16,
+                                    tileHeight: contentSize.height / 32,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_controls.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_controls.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+
+class NumberField extends StatelessWidget {
+  const NumberField({
+    required this.label,
+    required this.enabled,
+    required this.controller,
+    required this.hint,
+    required this.onSubmitted,
+    super.key,
+  });
+
+  final String label;
+  final bool enabled;
+  final TextEditingController controller;
+  final String hint;
+  final ValueChanged<String> onSubmitted;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      enabled: enabled,
+      controller: controller
+        ..selection = TextSelection.fromPosition(
+          TextPosition(offset: controller.text.length),
+        ),
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        isDense: true,
+        filled: true,
+        fillColor: Theme.of(context).colorScheme.surfaceContainerLowest,
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
+      ),
+      keyboardType: TextInputType.number,
+      onSubmitted: onSubmitted,
+    );
+  }
+}
+
+/// Hex address input with 4-button navigation (Mesen2 style).
+class AddressInput extends StatelessWidget {
+  const AddressInput({
+    required this.value,
+    required this.maxValue,
+    required this.pageIncrement,
+    required this.onChanged,
+    this.byteIncrement = 1,
+    super.key,
+  });
+
+  final int value;
+  final int maxValue;
+  final int pageIncrement;
+  final int byteIncrement;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hexValue =
+        '\$${value.toRadixString(16).toUpperCase().padLeft(4, '0')}';
+
+    Widget navButton(String label, int delta, {bool enabled = true}) {
+      return InkWell(
+        onTap: enabled
+            ? () => onChanged((value + delta).clamp(0, maxValue))
+            : null,
+        borderRadius: BorderRadius.circular(4),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+          child: Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontFamily: 'monospace',
+              fontWeight: FontWeight.bold,
+              color: enabled
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurface.withValues(alpha: 0.3),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Row(
+      children: [
+        navButton('«', -pageIncrement, enabled: value > 0),
+        navButton('<', -byteIncrement, enabled: value > 0),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              border: Border.all(color: theme.colorScheme.outlineVariant),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              hexValue,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ),
+        navButton('>', byteIncrement, enabled: value < maxValue),
+        navButton(
+          '»',
+          pageIncrement,
+          enabled: value < maxValue - pageIncrement + 1,
+        ),
+      ],
+    );
+  }
+}
+
+class SizeInput extends StatelessWidget {
+  const SizeInput({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.step,
+    required this.onChanged,
+    super.key,
+  });
+
+  final String label;
+  final int value;
+  final int min;
+  final int max;
+  final int step;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          children: [
+            InkWell(
+              onTap: value > min
+                  ? () => onChanged((value - step).clamp(min, max))
+                  : null,
+              borderRadius: BorderRadius.circular(4),
+              child: Container(
+                padding: const EdgeInsets.all(4),
+                child: Icon(
+                  Icons.remove,
+                  size: 16,
+                  color: value > min
+                      ? theme.colorScheme.onSurface
+                      : theme.colorScheme.onSurface.withValues(alpha: 0.3),
+                ),
+              ),
+            ),
+            Expanded(
+              child: Text(
+                '$value',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            InkWell(
+              onTap: value < max
+                  ? () => onChanged((value + step).clamp(min, max))
+                  : null,
+              borderRadius: BorderRadius.circular(4),
+              child: Container(
+                padding: const EdgeInsets.all(4),
+                child: Icon(
+                  Icons.add,
+                  size: 16,
+                  color: value < max
+                      ? theme.colorScheme.onSurface
+                      : theme.colorScheme.onSurface.withValues(alpha: 0.3),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class SideSection extends StatelessWidget {
+  const SideSection({required this.title, required this.child, super.key});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        elevation: 0,
+        color: colorScheme.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 10),
+              child,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_geometry.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_geometry.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+
+const int tileViewerColumns = 16;
+const int tileViewerRows = 32;
+
+String tileViewerHex(int value, {int width = 4}) =>
+    '\$${value.toRadixString(16).toUpperCase().padLeft(width, '0')}';
+
+TileCoord? tileAtPosition(Offset position, Size contentSize) {
+  if (contentSize.width <= 0 || contentSize.height <= 0) return null;
+  if (position.dx < 0 ||
+      position.dy < 0 ||
+      position.dx > contentSize.width ||
+      position.dy > contentSize.height) {
+    return null;
+  }
+
+  final tileWidth = contentSize.width / tileViewerColumns;
+  final tileHeight = contentSize.height / tileViewerRows;
+  final x = (position.dx / tileWidth).floor().clamp(0, tileViewerColumns - 1);
+  final y = (position.dy / tileHeight).floor().clamp(0, tileViewerRows - 1);
+  return TileCoord(x, y);
+}
+
+TileInfo computeTileInfo(TileCoord tile) {
+  final tileIndex = tile.y * tileViewerColumns + tile.x;
+  final patternTable = tileIndex >= 256 ? 1 : 0;
+  final tileIndexInTable = tileIndex % 256;
+  final chrAddress = patternTable * 0x1000 + tileIndexInTable * 16;
+
+  return TileInfo(
+    tileIndex: tileIndex,
+    patternTable: patternTable,
+    tileIndexInTable: tileIndexInTable,
+    chrAddress: chrAddress,
+  );
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_models.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_models.dart
@@ -1,0 +1,58 @@
+/// Memory source for tile data (matches Rust backend).
+enum TileSource { ppu, chrRom, chrRam, prgRom }
+
+/// Tile layout mode (matches Rust backend).
+enum TileLayout { normal, singleLine8x16, singleLine16x16 }
+
+/// Tile background color (matches Rust backend).
+enum TileBackground {
+  defaultBg,
+  transparent,
+  paletteColor,
+  black,
+  white,
+  magenta,
+}
+
+/// All Mesen2-style presets (both source and palette presets).
+enum TilePreset { ppu, chr, rom, bg, oam }
+
+enum TileCaptureMode { frameStart, vblankStart, scanline }
+
+/// Tile coordinate in the CHR grid (0-15 for x, 0-31 for y).
+class TileCoord {
+  const TileCoord(this.x, this.y);
+
+  final int x;
+  final int y;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TileCoord && x == other.x && y == other.y;
+
+  @override
+  int get hashCode => Object.hash(x, y);
+}
+
+/// Tile information for tooltip display.
+class TileInfo {
+  const TileInfo({
+    required this.tileIndex,
+    required this.patternTable,
+    required this.tileIndexInTable,
+    required this.chrAddress,
+  });
+
+  /// 0-511 global index across both pattern tables.
+  final int tileIndex;
+
+  /// 0 or 1.
+  final int patternTable;
+
+  /// 0-255 index within the pattern table.
+  final int tileIndexInTable;
+
+  /// CHR address ($0000-$1FFF).
+  final int chrAddress;
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_painters.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_painters.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_geometry.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+
+class TileGridPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white.withValues(alpha: 0.2)
+      ..strokeWidth = 1.0
+      ..style = PaintingStyle.stroke;
+
+    final tileWidth = size.width / tileViewerColumns;
+    final tileHeight = size.height / tileViewerRows;
+
+    for (var i = 0; i <= tileViewerColumns; i++) {
+      final x = i * tileWidth;
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+    }
+
+    for (var i = 0; i <= tileViewerRows; i++) {
+      final y = i * tileHeight;
+      canvas.drawLine(Offset(0, y), Offset(size.width, y), paint);
+    }
+
+    final separatorY = 16 * tileHeight;
+    final separatorPaint = Paint()
+      ..color = Colors.yellow.withValues(alpha: 0.5)
+      ..strokeWidth = 2.0;
+    canvas.drawLine(
+      Offset(0, separatorY),
+      Offset(size.width, separatorY),
+      separatorPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+/// Paints highlight for hovered and selected tiles.
+class TileHighlightPainter extends CustomPainter {
+  TileHighlightPainter({
+    required this.tileWidth,
+    required this.tileHeight,
+    this.hoveredTile,
+    this.selectedTile,
+  });
+
+  final TileCoord? hoveredTile;
+  final TileCoord? selectedTile;
+  final double tileWidth;
+  final double tileHeight;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (hoveredTile != null) {
+      final rect = Rect.fromLTWH(
+        hoveredTile!.x * tileWidth,
+        hoveredTile!.y * tileHeight,
+        tileWidth,
+        tileHeight,
+      );
+      final paint = Paint()
+        ..color = Colors.cyan.withValues(alpha: 0.3)
+        ..style = PaintingStyle.fill;
+      canvas.drawRect(rect, paint);
+
+      final borderPaint = Paint()
+        ..color = Colors.cyan
+        ..strokeWidth = 1.5
+        ..style = PaintingStyle.stroke;
+      canvas.drawRect(rect, borderPaint);
+    }
+
+    if (selectedTile != null && selectedTile != hoveredTile) {
+      final rect = Rect.fromLTWH(
+        selectedTile!.x * tileWidth,
+        selectedTile!.y * tileHeight,
+        tileWidth,
+        tileHeight,
+      );
+      final paint = Paint()
+        ..color = Colors.yellow.withValues(alpha: 0.4)
+        ..style = PaintingStyle.fill;
+      canvas.drawRect(rect, paint);
+
+      final borderPaint = Paint()
+        ..color = Colors.yellow
+        ..strokeWidth = 2.0
+        ..style = PaintingStyle.stroke;
+      canvas.drawRect(rect, borderPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant TileHighlightPainter oldDelegate) =>
+      hoveredTile != oldDelegate.hoveredTile ||
+      selectedTile != oldDelegate.selectedTile;
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_settings_menu.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_settings_menu.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_preset_buttons.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_controls.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+import 'package:nesium_flutter/widgets/animated_dropdown_menu.dart';
+
+class TileViewerSettingsButton extends StatelessWidget {
+  const TileViewerSettingsButton({
+    required this.selectedPreset,
+    required this.onPresetSelected,
+    required this.showTileGrid,
+    required this.onShowTileGridChanged,
+    required this.useGrayscale,
+    required this.onUseGrayscaleChanged,
+    required this.captureMode,
+    required this.onCaptureModeChanged,
+    required this.scanlineController,
+    required this.dotController,
+    required this.minScanline,
+    required this.maxScanline,
+    required this.minDot,
+    required this.maxDot,
+    required this.onScanlineSubmitted,
+    required this.onDotSubmitted,
+    required this.selectedPalette,
+    required this.onPaletteChanged,
+    super.key,
+  });
+
+  final TilePreset? selectedPreset;
+  final ValueChanged<TilePreset> onPresetSelected;
+  final bool showTileGrid;
+  final ValueChanged<bool> onShowTileGridChanged;
+  final bool useGrayscale;
+  final ValueChanged<bool> onUseGrayscaleChanged;
+  final TileCaptureMode captureMode;
+  final ValueChanged<TileCaptureMode> onCaptureModeChanged;
+  final TextEditingController scanlineController;
+  final TextEditingController dotController;
+  final int minScanline;
+  final int maxScanline;
+  final int minDot;
+  final int maxDot;
+  final ValueChanged<String> onScanlineSubmitted;
+  final ValueChanged<String> onDotSubmitted;
+  final int selectedPalette;
+  final ValueChanged<int> onPaletteChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Builder(
+      builder: (buttonContext) {
+        return IconButton(
+          icon: Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest.withValues(
+                alpha: 0.8,
+              ),
+              borderRadius: BorderRadius.circular(8),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.1),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Icon(
+              Icons.settings,
+              color: theme.colorScheme.onSurface,
+              size: 20,
+            ),
+          ),
+          tooltip: l10n.tileViewerSettings,
+          onPressed: () => _showSettingsMenu(buttonContext),
+        );
+      },
+    );
+  }
+
+  void _showSettingsMenu(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    var menuPreset = selectedPreset;
+    var menuShowTileGrid = showTileGrid;
+    var menuUseGrayscale = useGrayscale;
+    var menuCaptureMode = captureMode;
+    var menuSelectedPalette = selectedPalette;
+
+    final button = context.findRenderObject()! as RenderBox;
+    final overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final buttonPosition = button.localToGlobal(Offset.zero, ancestor: overlay);
+
+    showMenu<void>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        buttonPosition.dx + button.size.width - 280,
+        buttonPosition.dy + button.size.height + 4,
+        overlay.size.width - buttonPosition.dx - button.size.width,
+        0,
+      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      items: [
+        PopupMenuItem<void>(
+          enabled: false,
+          height: 32,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            l10n.tileViewerPresets,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        PopupMenuItem<void>(
+          onTap: () {},
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: StatefulBuilder(
+            builder: (context, setMenuState) => TilePresetButtons(
+              presets: const [TilePreset.ppu, TilePreset.chr, TilePreset.rom],
+              selectedPreset: menuPreset,
+              onSelected: (preset) {
+                menuPreset = preset;
+                onPresetSelected(preset);
+                setMenuState(() {});
+              },
+            ),
+          ),
+        ),
+        PopupMenuItem<void>(
+          onTap: () {},
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: StatefulBuilder(
+            builder: (context, setMenuState) => TilePresetButtons(
+              presets: const [TilePreset.bg, TilePreset.oam],
+              selectedPreset: menuPreset,
+              onSelected: (preset) {
+                menuPreset = preset;
+                onPresetSelected(preset);
+                setMenuState(() {});
+              },
+            ),
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<void>(
+          enabled: false,
+          height: 32,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            l10n.tileViewerOverlays,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        PopupMenuItem<void>(
+          onTap: () {},
+          padding: EdgeInsets.zero,
+          child: StatefulBuilder(
+            builder: (context, setMenuState) => CheckboxListTile(
+              dense: true,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              title: Text(l10n.tileViewerShowGrid),
+              value: menuShowTileGrid,
+              onChanged: (v) {
+                menuShowTileGrid = v ?? false;
+                onShowTileGridChanged(menuShowTileGrid);
+                setMenuState(() {});
+              },
+            ),
+          ),
+        ),
+        PopupMenuItem<void>(
+          onTap: () {},
+          padding: EdgeInsets.zero,
+          child: StatefulBuilder(
+            builder: (context, setMenuState) => CheckboxListTile(
+              dense: true,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              title: Text(l10n.tileViewerGrayscale),
+              value: menuUseGrayscale,
+              onChanged: (v) {
+                menuUseGrayscale = v ?? false;
+                onUseGrayscaleChanged(menuUseGrayscale);
+                setMenuState(() {});
+              },
+            ),
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<void>(
+          enabled: false,
+          height: 32,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            l10n.tilemapCapture,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        PopupMenuItem<void>(
+          onTap: () {},
+          padding: EdgeInsets.zero,
+          child: StatefulBuilder(
+            builder: (context, setMenuState) => Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                RadioGroup<TileCaptureMode>(
+                  groupValue: menuCaptureMode,
+                  onChanged: (v) {
+                    if (v == null) return;
+                    menuCaptureMode = v;
+                    onCaptureModeChanged(v);
+                    setMenuState(() {});
+                  },
+                  child: Column(
+                    children: [
+                      RadioListTile<TileCaptureMode>(
+                        dense: true,
+                        visualDensity: VisualDensity.compact,
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                        ),
+                        title: Text(l10n.tilemapCaptureFrameStart),
+                        value: TileCaptureMode.frameStart,
+                      ),
+                      RadioListTile<TileCaptureMode>(
+                        dense: true,
+                        visualDensity: VisualDensity.compact,
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                        ),
+                        title: Text(l10n.tilemapCaptureVblankStart),
+                        value: TileCaptureMode.vblankStart,
+                      ),
+                      RadioListTile<TileCaptureMode>(
+                        dense: true,
+                        visualDensity: VisualDensity.compact,
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                        ),
+                        title: Text(l10n.tilemapCaptureManual),
+                        value: TileCaptureMode.scanline,
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: NumberField(
+                          label: l10n.tilemapScanline,
+                          enabled: menuCaptureMode == TileCaptureMode.scanline,
+                          controller: scanlineController,
+                          hint: '$minScanline ~ $maxScanline',
+                          onSubmitted: (v) {
+                            onScanlineSubmitted(v);
+                            setMenuState(() {});
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: NumberField(
+                          label: l10n.tilemapDot,
+                          enabled: menuCaptureMode == TileCaptureMode.scanline,
+                          controller: dotController,
+                          hint: '$minDot ~ $maxDot',
+                          onSubmitted: (v) {
+                            onDotSubmitted(v);
+                            setMenuState(() {});
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const PopupMenuDivider(height: 1),
+        PopupMenuItem<void>(
+          enabled: false,
+          height: 32,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            l10n.tileViewerPalette,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.primary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        PopupMenuItem<void>(
+          enabled: false,
+          padding: EdgeInsets.zero,
+          child: StatefulBuilder(
+            builder: (context, setMenuState) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: AnimatedDropdownMenu<int>(
+                density: AnimatedDropdownMenuDensity.compact,
+                value: menuSelectedPalette,
+                entries: [
+                  for (var i = 0; i < 8; i++)
+                    DropdownMenuEntry(
+                      value: i,
+                      label: i < 4
+                          ? l10n.tileViewerPaletteBg(i)
+                          : l10n.tileViewerPaletteSprite(i - 4),
+                    ),
+                ],
+                onSelected: (v) {
+                  menuSelectedPalette = v;
+                  menuPreset = null;
+                  onPaletteChanged(v);
+                  setMenuState(() {});
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_side_panel.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile/tile_viewer_side_panel.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:nesium_flutter/bridge/api/events.dart' as bridge;
+import 'package:nesium_flutter/features/debugger/tile/tile_info_widgets.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_preset_buttons.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_controls.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+import 'package:nesium_flutter/l10n/app_localizations.dart';
+import 'package:nesium_flutter/widgets/animated_dropdown_menu.dart';
+import 'package:nesium_flutter/widgets/single_position_scrollbar.dart';
+
+class TileViewerSidePanel extends StatelessWidget {
+  const TileViewerSidePanel({
+    required this.snapshot,
+    required this.selectedTile,
+    required this.selectedPreset,
+    required this.onPresetSelected,
+    required this.captureMode,
+    required this.onCaptureModeChanged,
+    required this.scanlineController,
+    required this.dotController,
+    required this.minScanline,
+    required this.maxScanline,
+    required this.minDot,
+    required this.maxDot,
+    required this.onScanlineSubmitted,
+    required this.onDotSubmitted,
+    required this.source,
+    required this.onSourceChanged,
+    required this.startAddress,
+    required this.maxAddress,
+    required this.addressIncrement,
+    required this.onStartAddressChanged,
+    required this.columnCount,
+    required this.rowCount,
+    required this.layout,
+    required this.onColumnsChanged,
+    required this.onRowsChanged,
+    required this.onLayoutChanged,
+    required this.background,
+    required this.onBackgroundChanged,
+    required this.showTileGrid,
+    required this.onShowTileGridChanged,
+    required this.useGrayscale,
+    required this.onUseGrayscaleChanged,
+    required this.selectedPalette,
+    required this.onPaletteChanged,
+    super.key,
+  });
+
+  final bridge.TileSnapshot? snapshot;
+  final TileCoord? selectedTile;
+  final TilePreset? selectedPreset;
+  final ValueChanged<TilePreset> onPresetSelected;
+  final TileCaptureMode captureMode;
+  final ValueChanged<TileCaptureMode> onCaptureModeChanged;
+  final TextEditingController scanlineController;
+  final TextEditingController dotController;
+  final int minScanline;
+  final int maxScanline;
+  final int minDot;
+  final int maxDot;
+  final ValueChanged<String> onScanlineSubmitted;
+  final ValueChanged<String> onDotSubmitted;
+  final TileSource source;
+  final ValueChanged<TileSource> onSourceChanged;
+  final int startAddress;
+  final int maxAddress;
+  final int addressIncrement;
+  final ValueChanged<int> onStartAddressChanged;
+  final int columnCount;
+  final int rowCount;
+  final TileLayout layout;
+  final ValueChanged<int> onColumnsChanged;
+  final ValueChanged<int> onRowsChanged;
+  final ValueChanged<TileLayout> onLayoutChanged;
+  final TileBackground background;
+  final ValueChanged<TileBackground> onBackgroundChanged;
+  final bool showTileGrid;
+  final ValueChanged<bool> onShowTileGridChanged;
+  final bool useGrayscale;
+  final ValueChanged<bool> onUseGrayscaleChanged;
+  final int selectedPalette;
+  final ValueChanged<int> onPaletteChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerLowest,
+        border: Border(left: BorderSide(color: colorScheme.outlineVariant)),
+      ),
+      child: SinglePositionScrollbar(
+        thumbVisibility: true,
+        builder: (context, controller) {
+          return ListView(
+            controller: controller,
+            primary: false,
+            padding: const EdgeInsets.all(12),
+            children: [
+              SideSection(
+                title: l10n.tileViewerPresets,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TilePresetButtons(
+                      presets: const [
+                        TilePreset.ppu,
+                        TilePreset.chr,
+                        TilePreset.rom,
+                      ],
+                      selectedPreset: selectedPreset,
+                      onSelected: onPresetSelected,
+                    ),
+                    const SizedBox(height: 8),
+                    TilePresetButtons(
+                      presets: const [TilePreset.bg, TilePreset.oam],
+                      selectedPreset: selectedPreset,
+                      onSelected: onPresetSelected,
+                    ),
+                  ],
+                ),
+              ),
+              SideSection(
+                title: l10n.tilemapCapture,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    RadioGroup<TileCaptureMode>(
+                      groupValue: captureMode,
+                      onChanged: (v) {
+                        if (v == null) return;
+                        onCaptureModeChanged(v);
+                      },
+                      child: Column(
+                        children: [
+                          RadioListTile<TileCaptureMode>(
+                            dense: true,
+                            visualDensity: VisualDensity.compact,
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(l10n.tilemapCaptureFrameStart),
+                            value: TileCaptureMode.frameStart,
+                          ),
+                          RadioListTile<TileCaptureMode>(
+                            dense: true,
+                            visualDensity: VisualDensity.compact,
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(l10n.tilemapCaptureVblankStart),
+                            value: TileCaptureMode.vblankStart,
+                          ),
+                          RadioListTile<TileCaptureMode>(
+                            dense: true,
+                            visualDensity: VisualDensity.compact,
+                            contentPadding: EdgeInsets.zero,
+                            title: Text(l10n.tilemapCaptureManual),
+                            value: TileCaptureMode.scanline,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: NumberField(
+                            label: l10n.tilemapScanline,
+                            enabled: captureMode == TileCaptureMode.scanline,
+                            controller: scanlineController,
+                            hint: '$minScanline ~ $maxScanline',
+                            onSubmitted: onScanlineSubmitted,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: NumberField(
+                            label: l10n.tilemapDot,
+                            enabled: captureMode == TileCaptureMode.scanline,
+                            controller: dotController,
+                            hint: '$minDot ~ $maxDot',
+                            onSubmitted: onDotSubmitted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              SideSection(
+                title: l10n.tileViewerSource,
+                child: AnimatedDropdownMenu<TileSource>(
+                  density: AnimatedDropdownMenuDensity.compact,
+                  value: source,
+                  entries: [
+                    DropdownMenuEntry(
+                      value: TileSource.ppu,
+                      label: l10n.tileViewerSourcePpu,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileSource.chrRom,
+                      label: l10n.tileViewerSourceChrRom,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileSource.chrRam,
+                      label: l10n.tileViewerSourceChrRam,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileSource.prgRom,
+                      label: l10n.tileViewerSourcePrgRom,
+                    ),
+                  ],
+                  onSelected: onSourceChanged,
+                ),
+              ),
+              SideSection(
+                title: l10n.tileViewerAddress,
+                child: AddressInput(
+                  value: startAddress,
+                  maxValue: maxAddress,
+                  pageIncrement: addressIncrement,
+                  byteIncrement: 1,
+                  onChanged: onStartAddressChanged,
+                ),
+              ),
+              SideSection(
+                title: l10n.tileViewerSize,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: SizeInput(
+                        label: l10n.tileViewerColumns,
+                        value: columnCount,
+                        min: 4,
+                        max: 256,
+                        step: layout == TileLayout.normal ? 1 : 2,
+                        onChanged: onColumnsChanged,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: SizeInput(
+                        label: l10n.tileViewerRows,
+                        value: rowCount,
+                        min: 4,
+                        max: 256,
+                        step: layout == TileLayout.normal ? 1 : 2,
+                        onChanged: onRowsChanged,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SideSection(
+                title: l10n.tileViewerLayout,
+                child: AnimatedDropdownMenu<TileLayout>(
+                  density: AnimatedDropdownMenuDensity.compact,
+                  value: layout,
+                  entries: [
+                    DropdownMenuEntry(
+                      value: TileLayout.normal,
+                      label: l10n.tileViewerLayoutNormal,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileLayout.singleLine8x16,
+                      label: l10n.tileViewerLayout8x16,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileLayout.singleLine16x16,
+                      label: l10n.tileViewerLayout16x16,
+                    ),
+                  ],
+                  onSelected: onLayoutChanged,
+                ),
+              ),
+              SideSection(
+                title: l10n.tileViewerBackground,
+                child: AnimatedDropdownMenu<TileBackground>(
+                  density: AnimatedDropdownMenuDensity.compact,
+                  value: background,
+                  entries: [
+                    DropdownMenuEntry(
+                      value: TileBackground.defaultBg,
+                      label: l10n.tileViewerBgDefault,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileBackground.transparent,
+                      label: l10n.tileViewerBgTransparent,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileBackground.paletteColor,
+                      label: l10n.tileViewerBgPalette,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileBackground.black,
+                      label: l10n.tileViewerBgBlack,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileBackground.white,
+                      label: l10n.tileViewerBgWhite,
+                    ),
+                    DropdownMenuEntry(
+                      value: TileBackground.magenta,
+                      label: l10n.tileViewerBgMagenta,
+                    ),
+                  ],
+                  onSelected: onBackgroundChanged,
+                ),
+              ),
+              SideSection(
+                title: l10n.tileViewerOverlays,
+                child: Column(
+                  children: [
+                    CheckboxListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.trailing,
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(l10n.tileViewerShowGrid),
+                      value: showTileGrid,
+                      onChanged: (v) => onShowTileGridChanged(v ?? false),
+                    ),
+                    CheckboxListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.trailing,
+                      contentPadding: EdgeInsets.zero,
+                      title: Text(l10n.tileViewerGrayscale),
+                      value: useGrayscale,
+                      onChanged: (v) => onUseGrayscaleChanged(v ?? false),
+                    ),
+                  ],
+                ),
+              ),
+              SideSection(
+                title: l10n.tileViewerPalette,
+                child: _PaletteDropdown(
+                  selectedPalette: selectedPalette,
+                  onPaletteChanged: onPaletteChanged,
+                ),
+              ),
+              if (selectedTile != null && snapshot != null)
+                SideSection(
+                  title: l10n.tileViewerSelectedTile,
+                  child: TileInfoCard(tile: selectedTile!, snapshot: snapshot!),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PaletteDropdown extends StatelessWidget {
+  const _PaletteDropdown({
+    required this.selectedPalette,
+    required this.onPaletteChanged,
+  });
+
+  final int selectedPalette;
+  final ValueChanged<int> onPaletteChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return AnimatedDropdownMenu<int>(
+      density: AnimatedDropdownMenuDensity.compact,
+      value: selectedPalette,
+      entries: [
+        for (var i = 0; i < 8; i++)
+          DropdownMenuEntry(
+            value: i,
+            label: i < 4
+                ? l10n.tileViewerPaletteBg(i)
+                : l10n.tileViewerPaletteSprite(i - 4),
+          ),
+      ],
+      onSelected: onPaletteChanged,
+    );
+  }
+}

--- a/apps/nesium_flutter/lib/features/debugger/tile_viewer.dart
+++ b/apps/nesium_flutter/lib/features/debugger/tile_viewer.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,12 +6,16 @@ import 'package:nesium_flutter/bridge/api/events.dart' as bridge;
 import 'package:nesium_flutter/domain/aux_texture_ids.dart';
 import 'package:nesium_flutter/domain/nes_controller.dart';
 import 'package:nesium_flutter/domain/nes_texture_service.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_info_widgets.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_canvas.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_geometry.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_models.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_settings_menu.dart';
+import 'package:nesium_flutter/features/debugger/tile/tile_viewer_side_panel.dart';
 import 'package:nesium_flutter/features/debugger/viewer_skeletonizer.dart';
 import 'package:nesium_flutter/l10n/app_localizations.dart';
 import 'package:nesium_flutter/logging/app_logger.dart';
 import 'package:nesium_flutter/platform/platform_capabilities.dart';
-import 'package:nesium_flutter/widgets/animated_dropdown_menu.dart';
-import 'package:nesium_flutter/widgets/single_position_scrollbar.dart';
 
 /// Tile Viewer that displays NES CHR pattern tables via a Flutter Texture.
 class TileViewer extends ConsumerStatefulWidget {
@@ -22,48 +25,31 @@ class TileViewer extends ConsumerStatefulWidget {
   ConsumerState<TileViewer> createState() => _TileViewerState();
 }
 
-/// Memory source for tile data (matches Rust backend)
-enum _TileSource { ppu, chrRom, chrRam, prgRom }
-
-/// Tile layout mode (matches Rust backend)
-enum _TileLayout { normal, singleLine8x16, singleLine16x16 }
-
-/// Tile background color (matches Rust backend)
-enum _TileBackground {
-  defaultBg,
-  transparent,
-  paletteColor,
-  black,
-  white,
-  magenta,
-}
-
-/// All Mesen2-style presets (both source and palette presets)
-enum _Preset { ppu, chr, rom, bg, oam }
-
-enum _CaptureMode { frameStart, vblankStart, scanline }
-
 class _TileViewerState extends ConsumerState<TileViewer> {
   static const int _minScanline = -1;
   static const int _maxScanline = 260;
   static const int _minDot = 0;
   static const int _maxDot = 340;
+  static const double _minScale = 1.0;
+  static const double _maxScale = 8.0;
 
   final NesTextureService _textureService = NesTextureService();
+  final TransformationController _transformationController =
+      TransformationController();
+
   int? _chrTextureId;
   int? _flutterTextureId;
   bool _isCreating = false;
   String? _error;
   StreamSubscription<bridge.TileSnapshot>? _tileSnapshotSub;
+  bridge.TileSnapshot? _tileSnapshot;
 
-  // Display options
   bool _showTileGrid = true;
-  int _selectedPalette = 0; // 0-7: 0-3 BG, 4-7 Sprite
+  int _selectedPalette = 0;
   bool _useGrayscale = false;
-  bool _showSidePanel = true; // Desktop side panel visibility
+  bool _showSidePanel = true;
 
-  // Capture mode state
-  _CaptureMode _captureMode = _CaptureMode.vblankStart;
+  TileCaptureMode _captureMode = TileCaptureMode.vblankStart;
   int _scanline = 0;
   int _dot = 0;
   late final TextEditingController _scanlineController = TextEditingController(
@@ -73,39 +59,23 @@ class _TileViewerState extends ConsumerState<TileViewer> {
     text: _dot.toString(),
   );
 
-  // Selected preset (null = no preset selected, manual config)
-  _Preset? _selectedPreset = _Preset.ppu;
-
-  // Configurable tile viewer options (synced with TileSnapshot)
-  _TileSource _source = _TileSource.ppu;
+  TilePreset? _selectedPreset = TilePreset.ppu;
+  TileSource _source = TileSource.ppu;
   int _startAddress = 0;
   int _columnCount = 16;
   int _rowCount = 32;
-  _TileLayout _layout = _TileLayout.normal;
-  _TileBackground _background = _TileBackground.defaultBg;
+  TileLayout _layout = TileLayout.normal;
+  TileBackground _background = TileBackground.defaultBg;
 
-  // Dynamic texture dimensions
+  TileCoord? _hoveredTile;
+  TileCoord? _selectedTile;
+  Offset? _hoverPosition;
+  bool _isCanvasTransformed = false;
+
   int get _textureWidth => _columnCount * 8;
   int get _textureHeight => _rowCount * 8;
-
-  // Max address for current source
   int get _maxAddress => (_tileSnapshot?.sourceSize ?? 0x2000) - 1;
-
-  // Address increment for page navigation
-  int get _addressIncrement => _columnCount * _rowCount * 16; // 16 bytes/tile
-
-  // Hover/selection for tile info tooltip
-  _TileCoord? _hoveredTile;
-  _TileCoord? _selectedTile;
-  Offset? _hoverPosition; // For floating tooltip positioning
-  bridge.TileSnapshot? _tileSnapshot; // Current snapshot for tile preview
-
-  // Zoom and pan state
-  final TransformationController _transformationController =
-      TransformationController();
-  static const double _minScale = 1.0;
-  static const double _maxScale = 8.0;
-  bool _isCanvasTransformed = false;
+  int get _addressIncrement => _columnCount * _rowCount * 16;
 
   @override
   void initState() {
@@ -114,9 +84,11 @@ class _TileViewerState extends ConsumerState<TileViewer> {
     _createTexture();
   }
 
-  /// Called when ROM is ejected - reset to PPU preset
   void _onRomEjected() {
-    _applyPreset(_Preset.ppu);
+    unawaitedLogged(
+      _applyPreset(TilePreset.ppu),
+      message: 'Failed to apply PPU tile preset',
+    );
   }
 
   void _onTransformChanged() {
@@ -131,18 +103,15 @@ class _TileViewerState extends ConsumerState<TileViewer> {
     _transformationController.value = Matrix4.identity();
   }
 
-  /// Updates tile viewer size (columns and/or rows) and recreates texture if needed
   Future<void> _updateSize({int? columns, int? rows}) async {
     final newColumns = columns ?? _columnCount;
     final newRows = rows ?? _rowCount;
-
-    // Apply restrictions for non-normal layouts
-    final adjustedColumns = _layout == _TileLayout.normal
+    final adjustedColumns = _layout == TileLayout.normal
         ? newColumns
-        : (newColumns ~/ 2) * 2; // Force even for 8x16/16x16
-    final adjustedRows = _layout == _TileLayout.normal
+        : (newColumns ~/ 2) * 2;
+    final adjustedRows = _layout == TileLayout.normal
         ? newRows
-        : (newRows ~/ 2) * 2; // Force even for 8x16/16x16
+        : (newRows ~/ 2) * 2;
 
     if (adjustedColumns == _columnCount && adjustedRows == _rowCount) return;
 
@@ -151,7 +120,6 @@ class _TileViewerState extends ConsumerState<TileViewer> {
       _rowCount = adjustedRows;
     });
 
-    // Notify backend and recreate texture
     await bridge.setTileViewerSize(
       columns: adjustedColumns,
       rows: adjustedRows,
@@ -159,7 +127,6 @@ class _TileViewerState extends ConsumerState<TileViewer> {
     await _recreateTexture();
   }
 
-  /// Recreates the texture with current dimensions
   Future<void> _recreateTexture() async {
     final ids = await AuxTextureIdsCache.get();
     _chrTextureId ??= ids.tile;
@@ -196,8 +163,6 @@ class _TileViewerState extends ConsumerState<TileViewer> {
       _tileSnapshotSub = bridge.tileStateStream().listen(
         (snap) {
           if (!mounted) return;
-          // Store snapshot for tooltip data WITHOUT triggering rebuild.
-          // Texture updates automatically; setState spam kills performance.
           _tileSnapshot = snap;
         },
         onError: (e, st) {
@@ -250,23 +215,8 @@ class _TileViewerState extends ConsumerState<TileViewer> {
     super.dispose();
   }
 
-  Future<void> _applyCaptureMode() async {
-    switch (_captureMode) {
-      case _CaptureMode.frameStart:
-        await bridge.setTileViewerCaptureFrameStart();
-      case _CaptureMode.vblankStart:
-        await bridge.setTileViewerCaptureVblankStart();
-      case _CaptureMode.scanline:
-        await bridge.setTileViewerCaptureScanline(
-          scanline: _scanline,
-          dot: _dot,
-        );
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    // Listen for ROM ejection to reset source to PPU
     ref.listen(nesControllerProvider, (prev, next) {
       final prevHasRom = prev?.romHash != null;
       final nextHasRom = next.romHash != null;
@@ -280,11 +230,10 @@ class _TileViewerState extends ConsumerState<TileViewer> {
     }
     final hasRom = ref.watch(nesControllerProvider).romHash != null;
     final loading = !hasRom || _isCreating || _flutterTextureId == null;
-    final base = ViewerSkeletonizer(
+    return ViewerSkeletonizer(
       enabled: loading,
       child: _buildMainLayout(context),
     );
-    return base;
   }
 
   Widget _buildErrorState() {
@@ -307,10 +256,9 @@ class _TileViewerState extends ConsumerState<TileViewer> {
   }
 
   Widget _buildMainLayout(BuildContext context) {
-    final tileView = _buildTileView(context);
+    final tileView = _buildTileView();
 
     if (isNativeDesktop) {
-      // Desktop layout with side panel
       return LayoutBuilder(
         builder: (context, constraints) {
           final size = constraints.biggest;
@@ -319,7 +267,7 @@ class _TileViewerState extends ConsumerState<TileViewer> {
               Row(
                 children: [
                   Expanded(child: tileView),
-                  _buildDesktopSidePanelWrapper(context),
+                  _buildDesktopSidePanelWrapper(),
                 ],
               ),
               Positioned(
@@ -333,24 +281,25 @@ class _TileViewerState extends ConsumerState<TileViewer> {
                   left: 12,
                   child: _buildResetZoomButton(context),
                 ),
-              // Floating hover tooltip (desktop only)
               if (_hoveredTile != null &&
                   _hoverPosition != null &&
                   _tileSnapshot != null)
-                _buildHoverTooltip(context, size),
+                TileHoverTooltip(
+                  tile: _hoveredTile!,
+                  snapshot: _tileSnapshot!,
+                  position: _hoverPosition!,
+                  viewportSize: size,
+                ),
             ],
           );
         },
       );
     }
 
-    // Mobile layout with popup menu
     return Stack(
       children: [
         tileView,
-        // Settings button (top-right)
-        Positioned(top: 12, right: 12, child: _buildSettingsButton(context)),
-        // Reset zoom button (bottom-left, only when transformed)
+        Positioned(top: 12, right: 12, child: _buildSettingsButton()),
         if (_isCanvasTransformed)
           Positioned(
             bottom: 12,
@@ -358,6 +307,106 @@ class _TileViewerState extends ConsumerState<TileViewer> {
             child: _buildResetZoomButton(context),
           ),
       ],
+    );
+  }
+
+  Widget _buildTileView() {
+    return TileViewerCanvas(
+      textureId: _flutterTextureId,
+      textureWidth: _textureWidth,
+      textureHeight: _textureHeight,
+      transformationController: _transformationController,
+      minScale: _minScale,
+      maxScale: _maxScale,
+      showTileGrid: _showTileGrid,
+      hoveredTile: _hoveredTile,
+      selectedTile: _selectedTile,
+      onHover: _handleHover,
+      onTap: _handleTap,
+      onHoverExit: _clearHover,
+    );
+  }
+
+  Widget _buildDesktopSidePanelWrapper() {
+    const panelWidth = 240.0;
+    return ClipRect(
+      child: TweenAnimationBuilder<double>(
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOut,
+        tween: Tween<double>(end: _showSidePanel ? 1.0 : 0.0),
+        builder: (context, factor, child) {
+          return IgnorePointer(
+            ignoring: factor == 0.0,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              widthFactor: factor,
+              child: child,
+            ),
+          );
+        },
+        child: SizedBox(
+          width: panelWidth,
+          child: TileViewerSidePanel(
+            snapshot: _tileSnapshot,
+            selectedTile: _selectedTile,
+            selectedPreset: _selectedPreset,
+            onPresetSelected: _setPreset,
+            captureMode: _captureMode,
+            onCaptureModeChanged: _setCaptureMode,
+            scanlineController: _scanlineController,
+            dotController: _dotController,
+            minScanline: _minScanline,
+            maxScanline: _maxScanline,
+            minDot: _minDot,
+            maxDot: _maxDot,
+            onScanlineSubmitted: _submitScanline,
+            onDotSubmitted: _submitDot,
+            source: _source,
+            onSourceChanged: _setSource,
+            startAddress: _startAddress,
+            maxAddress: _maxAddress,
+            addressIncrement: _addressIncrement,
+            onStartAddressChanged: _setStartAddress,
+            columnCount: _columnCount,
+            rowCount: _rowCount,
+            layout: _layout,
+            onColumnsChanged: (v) => unawaitedLogged(_updateSize(columns: v)),
+            onRowsChanged: (v) => unawaitedLogged(_updateSize(rows: v)),
+            onLayoutChanged: _setLayout,
+            background: _background,
+            onBackgroundChanged: _setBackground,
+            showTileGrid: _showTileGrid,
+            onShowTileGridChanged: (v) => setState(() => _showTileGrid = v),
+            useGrayscale: _useGrayscale,
+            onUseGrayscaleChanged: _setUseGrayscale,
+            selectedPalette: _selectedPalette,
+            onPaletteChanged: _setPalette,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingsButton() {
+    return TileViewerSettingsButton(
+      selectedPreset: _selectedPreset,
+      onPresetSelected: _setPreset,
+      showTileGrid: _showTileGrid,
+      onShowTileGridChanged: (v) => setState(() => _showTileGrid = v),
+      useGrayscale: _useGrayscale,
+      onUseGrayscaleChanged: _setUseGrayscale,
+      captureMode: _captureMode,
+      onCaptureModeChanged: _setCaptureMode,
+      scanlineController: _scanlineController,
+      dotController: _dotController,
+      minScanline: _minScanline,
+      maxScanline: _maxScanline,
+      minDot: _minDot,
+      maxDot: _maxDot,
+      onScanlineSubmitted: _submitScanline,
+      onDotSubmitted: _submitDot,
+      selectedPalette: _selectedPalette,
+      onPaletteChanged: _setPalette,
     );
   }
 
@@ -403,1240 +452,9 @@ class _TileViewerState extends ConsumerState<TileViewer> {
     );
   }
 
-  Widget _buildSettingsButton(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
-
-    return IconButton(
-      icon: Container(
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerHighest.withValues(
-            alpha: 0.8,
-          ),
-          borderRadius: BorderRadius.circular(8),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.1),
-              blurRadius: 4,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Icon(
-          Icons.settings,
-          color: theme.colorScheme.onSurface,
-          size: 20,
-        ),
-      ),
-      tooltip: l10n.tileViewerSettings,
-      onPressed: () => _showSettingsMenu(context),
-    );
-  }
-
-  /// Builds wrap of toggle buttons for presets with i18n labels
-  Widget _buildPresetButtons(
-    BuildContext context,
-    List<_Preset> presets, {
-    VoidCallback? onChanged,
-  }) {
-    final l10n = AppLocalizations.of(context)!;
-
-    String presetLabel(_Preset preset) => switch (preset) {
-      _Preset.ppu => l10n.tileViewerPresetPpu,
-      _Preset.chr => l10n.tileViewerPresetChr,
-      _Preset.rom => l10n.tileViewerPresetRom,
-      _Preset.bg => l10n.tileViewerPresetBg,
-      _Preset.oam => l10n.tileViewerPresetOam,
-    };
-
-    return Wrap(
-      spacing: 4,
-      runSpacing: 4,
-      children: presets.map((preset) {
-        final isSelected = _selectedPreset == preset;
-        return FilterChip(
-          label: Text(presetLabel(preset)),
-          selected: isSelected,
-          onSelected: (_) {
-            _applyPreset(preset);
-            onChanged?.call();
-          },
-          showCheckmark: false,
-          visualDensity: VisualDensity.compact,
-          labelPadding: const EdgeInsets.symmetric(horizontal: 4),
-        );
-      }).toList(),
-    );
-  }
-
-  /// Applies a preset configuration (Mesen2-style)
-  Future<void> _applyPreset(_Preset preset) async {
-    final snapshot = _tileSnapshot;
-
-    // Determine new settings based on preset
-    _TileSource newSource;
-    int newAddress;
-    int newColumns;
-    int newRows;
-    _TileLayout newLayout;
-    int? newPalette;
-
-    switch (preset) {
-      case _Preset.ppu:
-        newSource = _TileSource.ppu;
-        newAddress = 0;
-        newColumns = 16;
-        newRows = 32;
-        newLayout = _TileLayout.normal;
-        newPalette = null; // Keep current palette
-
-      case _Preset.chr:
-        // CHR ROM or CHR RAM (backend decides which is available)
-        newSource = _TileSource.chrRom;
-        newAddress = 0;
-        newColumns = 16;
-        newRows = 32;
-        newLayout = _TileLayout.normal;
-        newPalette = null;
-
-      case _Preset.rom:
-        newSource = _TileSource.prgRom;
-        newAddress = 0;
-        newColumns = 16;
-        newRows = 32;
-        newLayout = _TileLayout.normal;
-        newPalette = null;
-
-      case _Preset.bg:
-        // BG preset: use Background Pattern Table address from PPU
-        newSource = _TileSource.ppu;
-        newAddress = snapshot?.bgPatternBase ?? 0;
-        newColumns = 16;
-        newRows = 16; // Only one pattern table (16x16)
-        newLayout = _TileLayout.normal;
-        // Force palette to BG range (0-3)
-        newPalette = _selectedPalette >= 4 ? 0 : _selectedPalette;
-
-      case _Preset.oam:
-        // OAM preset: use Sprite Pattern Table address, handle 8x16 sprites
-        newSource = _TileSource.ppu;
-        final largeSprites = snapshot?.largeSprites ?? false;
-        if (largeSprites) {
-          // 8x16 sprite mode: show both tables with SingleLine8x16 layout
-          newAddress = 0;
-          newColumns = 16;
-          newRows = 32;
-          newLayout = _TileLayout.singleLine8x16;
-        } else {
-          // Normal 8x8 sprites: show sprite pattern table only
-          newAddress = snapshot?.spritePatternBase ?? 0;
-          newColumns = 16;
-          newRows = 16;
-          newLayout = _TileLayout.normal;
-        }
-        // Force palette to Sprite range (4-7)
-        newPalette = _selectedPalette < 4 ? 4 : _selectedPalette;
-    }
-
-    // Check if texture size changed
-    final needsTextureRecreate =
-        newColumns != _columnCount || newRows != _rowCount;
-
-    setState(() {
-      _selectedPreset = preset;
-      _source = newSource;
-      _startAddress = newAddress;
-      _columnCount = newColumns;
-      _rowCount = newRows;
-      _layout = newLayout;
-      if (newPalette != null) {
-        _selectedPalette = newPalette;
-      }
-    });
-
-    // Notify backend
-    await bridge.setTileViewerSource(source: newSource.index);
-    await bridge.setTileViewerStartAddress(startAddress: newAddress);
-    await bridge.setTileViewerSize(columns: newColumns, rows: newRows);
-    await bridge.setTileViewerLayout(layout: newLayout.index);
-    if (newPalette != null) {
-      await bridge.setTileViewerPalette(paletteIndex: newPalette);
-    }
-
-    // Recreate texture if size changed
-    if (needsTextureRecreate) {
-      await _recreateTexture();
-    }
-  }
-
-  /// Clears the preset selection (called when user manually changes settings)
-  void _clearPresetSelection() {
-    if (_selectedPreset != null) {
-      setState(() => _selectedPreset = null);
-    }
-  }
-
-  void _showSettingsMenu(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-
-    // Get button position for menu placement (positioned at top-right)
-    final RenderBox button = context.findRenderObject() as RenderBox;
-    final RenderBox overlay =
-        Overlay.of(context).context.findRenderObject() as RenderBox;
-    final buttonPosition = button.localToGlobal(Offset.zero, ancestor: overlay);
-
-    showMenu<void>(
-      context: context,
-      position: RelativeRect.fromLTRB(
-        buttonPosition.dx +
-            button.size.width -
-            280, // 280px menu width, aligned to button right
-        buttonPosition.dy +
-            button.size.height +
-            4, // Just below button with small gap
-        overlay.size.width -
-            buttonPosition.dx -
-            button.size.width, // Right edge
-        0,
-      ),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      items: [
-        PopupMenuItem<void>(
-          enabled: false,
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Text(
-            'Presets',
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
-        PopupMenuItem<void>(
-          onTap: () {}, // Empty tap to prevent closing
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => _buildPresetButtons(context, [
-              _Preset.ppu,
-              _Preset.chr,
-              _Preset.rom,
-            ], onChanged: () => setMenuState(() {})),
-          ),
-        ),
-        PopupMenuItem<void>(
-          onTap: () {}, // Empty tap to prevent closing
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => _buildPresetButtons(context, [
-              _Preset.bg,
-              _Preset.oam,
-            ], onChanged: () => setMenuState(() {})),
-          ),
-        ),
-        const PopupMenuDivider(),
-        // Overlay section header
-        PopupMenuItem<void>(
-          enabled: false,
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Text(
-            l10n.tileViewerOverlays,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
-        PopupMenuItem<void>(
-          onTap: () {}, // Empty tap to prevent closing
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => CheckboxListTile(
-              dense: true,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-              title: Text(l10n.tileViewerShowGrid),
-              value: _showTileGrid,
-              onChanged: (v) {
-                setState(() => _showTileGrid = v ?? false);
-                setMenuState(() {});
-              },
-            ),
-          ),
-        ),
-        PopupMenuItem<void>(
-          onTap: () {}, // Empty tap to prevent closing
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => CheckboxListTile(
-              dense: true,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-              title: Text(l10n.tileViewerGrayscale),
-              value: _useGrayscale,
-              onChanged: (v) async {
-                final enabled = v ?? false;
-                setState(() => _useGrayscale = enabled);
-                setMenuState(() {});
-                await bridge.setTileViewerDisplayMode(mode: enabled ? 1 : 0);
-              },
-            ),
-          ),
-        ),
-        const PopupMenuDivider(),
-        // Capture section header
-        PopupMenuItem<void>(
-          enabled: false,
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Text(
-            l10n.tilemapCapture,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
-        PopupMenuItem<void>(
-          onTap: () {}, // Empty tap to prevent closing
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                RadioGroup<_CaptureMode>(
-                  groupValue: _captureMode,
-                  onChanged: (v) {
-                    if (v == null) return;
-                    setState(() => _captureMode = v);
-                    setMenuState(() {});
-                    unawaitedLogged(
-                      _applyCaptureMode(),
-                      message: 'Failed to set CHR capture point',
-                    );
-                  },
-                  child: Column(
-                    children: [
-                      RadioListTile<_CaptureMode>(
-                        dense: true,
-                        visualDensity: VisualDensity.compact,
-                        contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                        ),
-                        title: Text(l10n.tilemapCaptureFrameStart),
-                        value: _CaptureMode.frameStart,
-                      ),
-                      RadioListTile<_CaptureMode>(
-                        dense: true,
-                        visualDensity: VisualDensity.compact,
-                        contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                        ),
-                        title: Text(l10n.tilemapCaptureVblankStart),
-                        value: _CaptureMode.vblankStart,
-                      ),
-                      RadioListTile<_CaptureMode>(
-                        dense: true,
-                        visualDensity: VisualDensity.compact,
-                        contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                        ),
-                        title: Text(l10n.tilemapCaptureManual),
-                        value: _CaptureMode.scanline,
-                      ),
-                    ],
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: _numberFieldModern(
-                          label: l10n.tilemapScanline,
-                          enabled: _captureMode == _CaptureMode.scanline,
-                          controller: _scanlineController,
-                          hint: '$_minScanline ~ $_maxScanline',
-                          onSubmitted: (v) {
-                            final value = int.tryParse(v);
-                            if (value == null ||
-                                value < _minScanline ||
-                                value > _maxScanline) {
-                              return;
-                            }
-                            setState(() => _scanline = value);
-                            setMenuState(() {});
-                            _scanlineController.text = _scanline.toString();
-                            unawaitedLogged(
-                              _applyCaptureMode(),
-                              message: 'Failed to set CHR capture point',
-                            );
-                          },
-                        ),
-                      ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: _numberFieldModern(
-                          label: l10n.tilemapDot,
-                          enabled: _captureMode == _CaptureMode.scanline,
-                          controller: _dotController,
-                          hint: '$_minDot ~ $_maxDot',
-                          onSubmitted: (v) {
-                            final value = int.tryParse(v);
-                            if (value == null ||
-                                value < _minDot ||
-                                value > _maxDot) {
-                              return;
-                            }
-                            setState(() => _dot = value);
-                            setMenuState(() {});
-                            _dotController.text = _dot.toString();
-                            unawaitedLogged(
-                              _applyCaptureMode(),
-                              message: 'Failed to set CHR capture point',
-                            );
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-        const PopupMenuDivider(height: 1),
-        // Palette section header
-        PopupMenuItem<void>(
-          enabled: false,
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Text(
-            l10n.tileViewerPalette,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.primary,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
-        PopupMenuItem<void>(
-          enabled: false,
-          padding: EdgeInsets.zero,
-          child: StatefulBuilder(
-            builder: (context, setMenuState) => Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: AnimatedDropdownMenu<int>(
-                density: AnimatedDropdownMenuDensity.compact,
-                value: _selectedPalette,
-                entries: [
-                  for (var i = 0; i < 8; i++)
-                    DropdownMenuEntry(
-                      value: i,
-                      label: i < 4
-                          ? l10n.tileViewerPaletteBg(i)
-                          : l10n.tileViewerPaletteSprite(i - 4),
-                    ),
-                ],
-                onSelected: (v) async {
-                  setState(() => _selectedPalette = v);
-                  _clearPresetSelection(); // Manual change clears preset
-                  setMenuState(() {});
-                  await bridge.setTileViewerPalette(paletteIndex: v);
-                },
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildTileView(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Container(
-      color: colorScheme.surfaceContainerLowest,
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border.all(color: colorScheme.outlineVariant, width: 1),
-          borderRadius: BorderRadius.circular(4),
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final viewportSize = constraints.biggest;
-            if (viewportSize.width <= 0 || viewportSize.height <= 0) {
-              return const SizedBox();
-            }
-
-            final scale = math.min(
-              viewportSize.width / _textureWidth,
-              viewportSize.height / _textureHeight,
-            );
-            final contentSize = Size(
-              _textureWidth * scale,
-              _textureHeight * scale,
-            );
-            final contentOffset = Offset(
-              (viewportSize.width - contentSize.width) / 2,
-              (viewportSize.height - contentSize.height) / 2,
-            );
-
-            return MouseRegion(
-              onHover: (event) => _handleHover(
-                event.localPosition,
-                contentOffset: contentOffset,
-                contentSize: contentSize,
-              ),
-              onExit: (_) => _clearHover(),
-              child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTapDown: (details) => _handleTap(
-                  details.localPosition,
-                  contentOffset: contentOffset,
-                  contentSize: contentSize,
-                ),
-                child: InteractiveViewer(
-                  transformationController: _transformationController,
-                  minScale: _minScale,
-                  maxScale: _maxScale,
-                  panEnabled: true,
-                  scaleEnabled: true,
-                  boundaryMargin: const EdgeInsets.all(double.infinity),
-                  constrained: false,
-                  child: SizedBox(
-                    width: viewportSize.width,
-                    height: viewportSize.height,
-                    child: Stack(
-                      children: [
-                        Positioned(
-                          left: contentOffset.dx,
-                          top: contentOffset.dy,
-                          width: contentSize.width,
-                          height: contentSize.height,
-                          child: Stack(
-                            fit: StackFit.expand,
-                            children: [
-                              if (_flutterTextureId != null &&
-                                  !ViewerSkeletonScope.enabledOf(context))
-                                Texture(
-                                  textureId: _flutterTextureId!,
-                                  filterQuality: FilterQuality.none,
-                                )
-                              else
-                                DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.surfaceContainerHighest,
-                                    borderRadius: BorderRadius.circular(12),
-                                  ),
-                                ),
-                              if (_showTileGrid)
-                                CustomPaint(painter: _TileGridPainter()),
-                              if (_hoveredTile != null || _selectedTile != null)
-                                CustomPaint(
-                                  painter: _TileHighlightPainter(
-                                    hoveredTile: _hoveredTile,
-                                    selectedTile: _selectedTile,
-                                    tileWidth: contentSize.width / 16,
-                                    tileHeight: contentSize.height / 32,
-                                  ),
-                                ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
-    );
-  }
-
-  void _handleHover(
-    Offset position, {
-    required Offset contentOffset,
-    required Size contentSize,
-  }) {
-    // Transform screen position to child position (handles zoom/pan), then map
-    // to the actual CHR texture rect within that child.
-    final childPos = _transformToContent(position);
-    final contentPos = childPos - contentOffset;
-    final tile = _tileAtPosition(contentPos, contentSize);
-    if (tile == _hoveredTile && position == _hoverPosition) return;
-    setState(() {
-      _hoveredTile = tile;
-      _hoverPosition = position; // Keep screen position for tooltip
-    });
-  }
-
-  void _clearHover() {
-    if (_hoveredTile == null) return;
-    setState(() {
-      _hoveredTile = null;
-      _hoverPosition = null;
-    });
-  }
-
-  void _handleTap(
-    Offset position, {
-    required Offset contentOffset,
-    required Size contentSize,
-  }) {
-    final childPos = _transformToContent(position);
-    final contentPos = childPos - contentOffset;
-    final tile = _tileAtPosition(contentPos, contentSize);
-    setState(() {
-      _selectedTile = tile;
-    });
-  }
-
-  /// Transform screen coordinates to content coordinates
-  /// accounting for zoom and pan transformation
-  Offset _transformToContent(Offset screenPos) {
-    final matrix = _transformationController.value;
-    // Apply inverse transformation
-    final inverted = Matrix4.inverted(matrix);
-    final result = MatrixUtils.transformPoint(inverted, screenPos);
-    return result;
-  }
-
-  _TileCoord? _tileAtPosition(Offset position, Size contentSize) {
-    if (contentSize.width <= 0 || contentSize.height <= 0) return null;
-    if (position.dx < 0 ||
-        position.dy < 0 ||
-        position.dx > contentSize.width ||
-        position.dy > contentSize.height) {
-      return null;
-    }
-
-    final tileWidth = contentSize.width / 16;
-    final tileHeight = contentSize.height / 32;
-    final x = (position.dx / tileWidth).floor().clamp(0, 15);
-    final y = (position.dy / tileHeight).floor().clamp(0, 31);
-    return _TileCoord(x, y);
-  }
-
-  _TileInfo? _computeTileInfo(_TileCoord tile) {
-    final tileIndex = tile.y * 16 + tile.x;
-    final patternTable = tileIndex >= 256 ? 1 : 0;
-    final tileIndexInTable = tileIndex % 256;
-    final chrAddress = patternTable * 0x1000 + tileIndexInTable * 16;
-
-    return _TileInfo(
-      tileIndex: tileIndex,
-      patternTable: patternTable,
-      tileIndexInTable: tileIndexInTable,
-      chrAddress: chrAddress,
-    );
-  }
-
-  /// Floating hover tooltip for desktop - positioned near cursor
-  Widget _buildHoverTooltip(BuildContext context, Size size) {
-    final tile = _hoveredTile;
-    final snap = _tileSnapshot;
-    final pos = _hoverPosition;
-    if (tile == null || snap == null || pos == null) return const SizedBox();
-
-    final info = _computeTileInfo(tile);
-    if (info == null) return const SizedBox();
-
-    const tooltipWidth = 220.0;
-    const tooltipHeight = 130.0; // Estimated actual height
-    const cursorOffset = 16.0;
-
-    final preferRight = pos.dx < size.width * 0.55;
-    final preferDown = pos.dy < size.height * 0.5;
-
-    // Calculate position with consistent offset from cursor
-    final dxCandidate = preferRight
-        ? pos.dx + cursorOffset
-        : pos.dx - tooltipWidth - cursorOffset;
-    final dyCandidate = preferDown
-        ? pos.dy + cursorOffset
-        : pos.dy - tooltipHeight - cursorOffset;
-
-    final dx = dxCandidate.clamp(8.0, size.width - tooltipWidth - 8.0);
-    final dy = dyCandidate.clamp(8.0, size.height - tooltipHeight - 8.0);
-
-    return Positioned(
-      left: dx,
-      top: dy,
-      child: SizedBox(
-        width: tooltipWidth,
-        child: _buildTileHoverCard(context, info: info, snapshot: snap),
-      ),
-    );
-  }
-
-  Widget _buildTileHoverCard(
-    BuildContext context, {
-    required _TileInfo info,
-    required bridge.TileSnapshot snapshot,
-  }) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Card(
-      elevation: 4,
-      shadowColor: colorScheme.shadow.withValues(alpha: 0.3),
-      color: colorScheme.surfaceContainerHigh,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-        side: BorderSide(color: colorScheme.outlineVariant),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _ChrTilePreview(snapshot: snapshot, info: info),
-            const SizedBox(width: 12),
-            Expanded(
-              child: DefaultTextStyle(
-                style: theme.textTheme.bodySmall!,
-                child: _TileInfoTable(context: context, info: info),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // ───────────────────────────── Desktop Side Panel ─────────────────────────
-
-  Widget _buildDesktopSidePanelWrapper(BuildContext context) {
-    const panelWidth = 240.0;
-    return ClipRect(
-      child: TweenAnimationBuilder<double>(
-        duration: const Duration(milliseconds: 180),
-        curve: Curves.easeOut,
-        tween: Tween<double>(end: _showSidePanel ? 1.0 : 0.0),
-        builder: (context, factor, child) {
-          return IgnorePointer(
-            ignoring: factor == 0.0,
-            child: Align(
-              alignment: Alignment.centerLeft,
-              widthFactor: factor,
-              child: child,
-            ),
-          );
-        },
-        child: SizedBox(
-          width: panelWidth,
-          child: _buildDesktopSidePanel(context),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDesktopSidePanel(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Container(
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerLowest,
-        border: Border(
-          left: BorderSide(color: colorScheme.outlineVariant, width: 1),
-        ),
-      ),
-      child: SinglePositionScrollbar(
-        thumbVisibility: true,
-        builder: (context, controller) {
-          return ListView(
-            controller: controller,
-            primary: false,
-            padding: const EdgeInsets.all(12),
-            children: [
-              _sideSection(
-                context,
-                title: l10n.tileViewerPresets,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _buildPresetButtons(context, [
-                      _Preset.ppu,
-                      _Preset.chr,
-                      _Preset.rom,
-                    ]),
-                    const SizedBox(height: 8),
-                    _buildPresetButtons(context, [_Preset.bg, _Preset.oam]),
-                  ],
-                ),
-              ),
-              _sideSection(
-                context,
-                title: l10n.tilemapCapture,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    RadioGroup<_CaptureMode>(
-                      groupValue: _captureMode,
-                      onChanged: (v) {
-                        if (v == null) return;
-                        setState(() => _captureMode = v);
-                        unawaitedLogged(
-                          _applyCaptureMode(),
-                          message: 'Failed to set CHR capture point',
-                        );
-                      },
-                      child: Column(
-                        children: [
-                          RadioListTile<_CaptureMode>(
-                            dense: true,
-                            visualDensity: VisualDensity.compact,
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(l10n.tilemapCaptureFrameStart),
-                            value: _CaptureMode.frameStart,
-                          ),
-                          RadioListTile<_CaptureMode>(
-                            dense: true,
-                            visualDensity: VisualDensity.compact,
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(l10n.tilemapCaptureVblankStart),
-                            value: _CaptureMode.vblankStart,
-                          ),
-                          RadioListTile<_CaptureMode>(
-                            dense: true,
-                            visualDensity: VisualDensity.compact,
-                            contentPadding: EdgeInsets.zero,
-                            title: Text(l10n.tilemapCaptureManual),
-                            value: _CaptureMode.scanline,
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: _numberFieldModern(
-                            label: l10n.tilemapScanline,
-                            enabled: _captureMode == _CaptureMode.scanline,
-                            controller: _scanlineController,
-                            hint: '$_minScanline ~ $_maxScanline',
-                            onSubmitted: (v) {
-                              final value = int.tryParse(v);
-                              if (value == null ||
-                                  value < _minScanline ||
-                                  value > _maxScanline) {
-                                return;
-                              }
-                              setState(() => _scanline = value);
-                              _scanlineController.text = _scanline.toString();
-                              unawaitedLogged(
-                                _applyCaptureMode(),
-                                message: 'Failed to set CHR capture point',
-                              );
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: 10),
-                        Expanded(
-                          child: _numberFieldModern(
-                            label: l10n.tilemapDot,
-                            enabled: _captureMode == _CaptureMode.scanline,
-                            controller: _dotController,
-                            hint: '$_minDot ~ $_maxDot',
-                            onSubmitted: (v) {
-                              final value = int.tryParse(v);
-                              if (value == null ||
-                                  value < _minDot ||
-                                  value > _maxDot) {
-                                return;
-                              }
-                              setState(() => _dot = value);
-                              _dotController.text = _dot.toString();
-                              unawaitedLogged(
-                                _applyCaptureMode(),
-                                message: 'Failed to set CHR capture point',
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              // Source selector
-              _sideSection(
-                context,
-                title: l10n.tileViewerSource,
-                child: AnimatedDropdownMenu<_TileSource>(
-                  density: AnimatedDropdownMenuDensity.compact,
-                  value: _source,
-                  entries: [
-                    DropdownMenuEntry(
-                      value: _TileSource.ppu,
-                      label: l10n.tileViewerSourcePpu,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileSource.chrRom,
-                      label: l10n.tileViewerSourceChrRom,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileSource.chrRam,
-                      label: l10n.tileViewerSourceChrRam,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileSource.prgRom,
-                      label: l10n.tileViewerSourcePrgRom,
-                    ),
-                  ],
-                  onSelected: (v) async {
-                    setState(() => _source = v);
-                    await bridge.setTileViewerSource(source: v.index);
-                  },
-                ),
-              ),
-              // Address input
-              _sideSection(
-                context,
-                title: l10n.tileViewerAddress,
-                child: _AddressInput(
-                  value: _startAddress,
-                  maxValue: _maxAddress,
-                  pageIncrement: _addressIncrement,
-                  byteIncrement: 1,
-                  onChanged: (v) async {
-                    setState(() => _startAddress = v);
-                    await bridge.setTileViewerStartAddress(startAddress: v);
-                  },
-                ),
-              ),
-              // Size selector (columns × rows)
-              _sideSection(
-                context,
-                title: l10n.tileViewerSize,
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: _SizeInput(
-                        label: l10n.tileViewerColumns,
-                        value: _columnCount,
-                        min: 4,
-                        max: 256,
-                        step: _layout == _TileLayout.normal ? 1 : 2,
-                        onChanged: (v) => _updateSize(columns: v),
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: _SizeInput(
-                        label: l10n.tileViewerRows,
-                        value: _rowCount,
-                        min: 4,
-                        max: 256,
-                        step: _layout == _TileLayout.normal ? 1 : 2,
-                        onChanged: (v) => _updateSize(rows: v),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              // Layout selector
-              _sideSection(
-                context,
-                title: l10n.tileViewerLayout,
-                child: AnimatedDropdownMenu<_TileLayout>(
-                  density: AnimatedDropdownMenuDensity.compact,
-                  value: _layout,
-                  entries: [
-                    DropdownMenuEntry(
-                      value: _TileLayout.normal,
-                      label: l10n.tileViewerLayoutNormal,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileLayout.singleLine8x16,
-                      label: l10n.tileViewerLayout8x16,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileLayout.singleLine16x16,
-                      label: l10n.tileViewerLayout16x16,
-                    ),
-                  ],
-                  onSelected: (v) async {
-                    setState(() => _layout = v);
-                    await bridge.setTileViewerLayout(layout: v.index);
-                  },
-                ),
-              ),
-              // Background selector
-              _sideSection(
-                context,
-                title: l10n.tileViewerBackground,
-                child: AnimatedDropdownMenu<_TileBackground>(
-                  density: AnimatedDropdownMenuDensity.compact,
-                  value: _background,
-                  entries: [
-                    DropdownMenuEntry(
-                      value: _TileBackground.defaultBg,
-                      label: l10n.tileViewerBgDefault,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileBackground.transparent,
-                      label: l10n.tileViewerBgTransparent,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileBackground.paletteColor,
-                      label: l10n.tileViewerBgPalette,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileBackground.black,
-                      label: l10n.tileViewerBgBlack,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileBackground.white,
-                      label: l10n.tileViewerBgWhite,
-                    ),
-                    DropdownMenuEntry(
-                      value: _TileBackground.magenta,
-                      label: l10n.tileViewerBgMagenta,
-                    ),
-                  ],
-                  onSelected: (v) async {
-                    setState(() => _background = v);
-                    await bridge.setTileViewerBackground(background: v.index);
-                  },
-                ),
-              ),
-              _sideSection(
-                context,
-                title: l10n.tileViewerOverlays,
-                child: Column(
-                  children: [
-                    CheckboxListTile(
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.trailing,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.tileViewerShowGrid),
-                      value: _showTileGrid,
-                      onChanged: (v) {
-                        setState(() => _showTileGrid = v ?? false);
-                      },
-                    ),
-                    CheckboxListTile(
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.trailing,
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(l10n.tileViewerGrayscale),
-                      value: _useGrayscale,
-                      onChanged: (v) async {
-                        final enabled = v ?? false;
-                        setState(() => _useGrayscale = enabled);
-                        await bridge.setTileViewerDisplayMode(
-                          mode: enabled ? 1 : 0,
-                        );
-                      },
-                    ),
-                  ],
-                ),
-              ),
-              _sideSection(
-                context,
-                title: l10n.tileViewerPalette,
-                child: AnimatedDropdownMenu<int>(
-                  density: AnimatedDropdownMenuDensity.compact,
-                  value: _selectedPalette,
-                  entries: [
-                    for (var i = 0; i < 8; i++)
-                      DropdownMenuEntry(
-                        value: i,
-                        label: i < 4
-                            ? l10n.tileViewerPaletteBg(i)
-                            : l10n.tileViewerPaletteSprite(i - 4),
-                      ),
-                  ],
-                  onSelected: (v) async {
-                    setState(() => _selectedPalette = v);
-                    _clearPresetSelection(); // Manual change clears preset
-                    await bridge.setTileViewerPalette(paletteIndex: v);
-                  },
-                ),
-              ),
-              // Selected Tile Info (only shows on tap/click, not hover)
-              if (_selectedTile != null && _tileSnapshot != null)
-                _sideSection(
-                  context,
-                  title: l10n.tileViewerSelectedTile,
-                  child: _buildTileInfoCard(
-                    context,
-                    _selectedTile!,
-                    _tileSnapshot!,
-                  ),
-                ),
-            ],
-          );
-        },
-      ),
-    );
-  }
-
-  /// Side panel tile info with preview (matching TilemapViewer TileInfoCard)
-  Widget _buildTileInfoCard(
-    BuildContext context,
-    _TileCoord tile,
-    bridge.TileSnapshot snapshot,
-  ) {
-    final info = _computeTileInfo(tile);
-    if (info == null) return const SizedBox.shrink();
-
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
-    final labelStyle = theme.textTheme.bodySmall?.copyWith(
-      color: theme.colorScheme.onSurfaceVariant,
-    );
-    final valueStyle = theme.textTheme.bodySmall?.copyWith(
-      fontWeight: FontWeight.w600,
-      fontFamily: 'monospace',
-    );
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SizedBox(
-              width: 76,
-              child: _ChrTilePreview(snapshot: snapshot, info: info),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                children: [
-                  _infoRow(
-                    l10n.tileViewerPatternTable,
-                    '${info.patternTable}',
-                    labelStyle,
-                    valueStyle,
-                  ),
-                  _infoRow(
-                    l10n.tileViewerTileIndex,
-                    '\$${info.tileIndexInTable.toRadixString(16).toUpperCase().padLeft(2, '0')}',
-                    labelStyle,
-                    valueStyle,
-                  ),
-                  _infoRow(
-                    l10n.tileViewerChrAddress,
-                    '\$${info.chrAddress.toRadixString(16).toUpperCase().padLeft(4, '0')}',
-                    labelStyle,
-                    valueStyle,
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  Widget _infoRow(
-    String label,
-    String value,
-    TextStyle? labelStyle,
-    TextStyle? valueStyle,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              label,
-              style: labelStyle,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Text(value, style: valueStyle),
-        ],
-      ),
-    );
-  }
-
-  Widget _sideSection(
-    BuildContext context, {
-    required String title,
-    required Widget child,
-  }) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Card(
-        elevation: 0,
-        color: colorScheme.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: colorScheme.outlineVariant),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(10),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(height: 10),
-              child,
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _numberFieldModern({
-    required String label,
-    required bool enabled,
-    required TextEditingController controller,
-    required String hint,
-    required ValueChanged<String> onSubmitted,
-  }) {
-    return TextField(
-      enabled: enabled,
-      controller: controller
-        ..selection = TextSelection.fromPosition(
-          TextPosition(offset: controller.text.length),
-        ),
-      decoration: InputDecoration(
-        labelText: label,
-        hintText: hint,
-        isDense: true,
-        filled: true,
-        fillColor: Theme.of(context).colorScheme.surfaceContainerLowest,
-        border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
-      ),
-      keyboardType: TextInputType.number,
-      onSubmitted: onSubmitted,
-    );
-  }
-
   Widget _buildPanelToggleButton(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
-
     final icon = _showSidePanel ? Icons.chevron_right : Icons.chevron_left;
     final tooltip = _showSidePanel
         ? l10n.tilemapHidePanel
@@ -1664,512 +482,235 @@ class _TileViewerState extends ConsumerState<TileViewer> {
       onPressed: () => setState(() => _showSidePanel = !_showSidePanel),
     );
   }
-}
 
-class _TileGridPainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = Colors.white.withValues(alpha: 0.2)
-      ..strokeWidth = 1.0
-      ..style = PaintingStyle.stroke;
-
-    // 16 tiles wide × 32 tiles tall
-    const tilesX = 16;
-    const tilesY = 32;
-
-    final tileWidth = size.width / tilesX;
-    final tileHeight = size.height / tilesY;
-
-    // Draw vertical lines
-    for (int i = 0; i <= tilesX; i++) {
-      final x = i * tileWidth;
-      canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
-    }
-
-    // Draw horizontal lines
-    for (int i = 0; i <= tilesY; i++) {
-      final y = i * tileHeight;
-      canvas.drawLine(Offset(0, y), Offset(size.width, y), paint);
-    }
-
-    // Draw separator between pattern tables (after row 16)
-    final separatorY = 16 * tileHeight;
-    final separatorPaint = Paint()
-      ..color = Colors.yellow.withValues(alpha: 0.5)
-      ..strokeWidth = 2.0;
-    canvas.drawLine(
-      Offset(0, separatorY),
-      Offset(size.width, separatorY),
-      separatorPaint,
-    );
+  void _handleHover({
+    required Offset position,
+    required Offset contentOffset,
+    required Size contentSize,
+  }) {
+    final childPos = _transformToContent(position);
+    final contentPos = childPos - contentOffset;
+    final tile = tileAtPosition(contentPos, contentSize);
+    if (tile == _hoveredTile && position == _hoverPosition) return;
+    setState(() {
+      _hoveredTile = tile;
+      _hoverPosition = position;
+    });
   }
 
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
-}
+  void _clearHover() {
+    if (_hoveredTile == null) return;
+    setState(() {
+      _hoveredTile = null;
+      _hoverPosition = null;
+    });
+  }
 
-/// Tile coordinate in the CHR grid (0-15 for x, 0-31 for y)
-class _TileCoord {
-  final int x;
-  final int y;
+  void _handleTap({
+    required Offset position,
+    required Offset contentOffset,
+    required Size contentSize,
+  }) {
+    final childPos = _transformToContent(position);
+    final contentPos = childPos - contentOffset;
+    final tile = tileAtPosition(contentPos, contentSize);
+    setState(() => _selectedTile = tile);
+  }
 
-  const _TileCoord(this.x, this.y);
+  Offset _transformToContent(Offset screenPos) {
+    final matrix = _transformationController.value;
+    final inverted = Matrix4.inverted(matrix);
+    return MatrixUtils.transformPoint(inverted, screenPos);
+  }
 
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is _TileCoord && x == other.x && y == other.y;
-
-  @override
-  int get hashCode => x.hashCode ^ y.hashCode;
-}
-
-/// Tile information for tooltip display
-class _TileInfo {
-  final int tileIndex; // 0-511 (global index across both pattern tables)
-  final int patternTable; // 0 or 1
-  final int tileIndexInTable; // 0-255 (index within the pattern table)
-  final int chrAddress; // CHR address ($0000-$1FFF)
-
-  const _TileInfo({
-    required this.tileIndex,
-    required this.patternTable,
-    required this.tileIndexInTable,
-    required this.chrAddress,
-  });
-}
-
-/// Paints highlight for hovered and selected tiles
-class _TileHighlightPainter extends CustomPainter {
-  final _TileCoord? hoveredTile;
-  final _TileCoord? selectedTile;
-  final double tileWidth;
-  final double tileHeight;
-
-  _TileHighlightPainter({
-    this.hoveredTile,
-    this.selectedTile,
-    required this.tileWidth,
-    required this.tileHeight,
-  });
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    // Draw hover highlight
-    if (hoveredTile != null) {
-      final rect = Rect.fromLTWH(
-        hoveredTile!.x * tileWidth,
-        hoveredTile!.y * tileHeight,
-        tileWidth,
-        tileHeight,
-      );
-      final paint = Paint()
-        ..color = Colors.cyan.withValues(alpha: 0.3)
-        ..style = PaintingStyle.fill;
-      canvas.drawRect(rect, paint);
-
-      final borderPaint = Paint()
-        ..color = Colors.cyan
-        ..strokeWidth = 1.5
-        ..style = PaintingStyle.stroke;
-      canvas.drawRect(rect, borderPaint);
-    }
-
-    // Draw selection highlight (stronger)
-    if (selectedTile != null && selectedTile != hoveredTile) {
-      final rect = Rect.fromLTWH(
-        selectedTile!.x * tileWidth,
-        selectedTile!.y * tileHeight,
-        tileWidth,
-        tileHeight,
-      );
-      final paint = Paint()
-        ..color = Colors.yellow.withValues(alpha: 0.4)
-        ..style = PaintingStyle.fill;
-      canvas.drawRect(rect, paint);
-
-      final borderPaint = Paint()
-        ..color = Colors.yellow
-        ..strokeWidth = 2.0
-        ..style = PaintingStyle.stroke;
-      canvas.drawRect(rect, borderPaint);
+  Future<void> _applyCaptureMode() async {
+    switch (_captureMode) {
+      case TileCaptureMode.frameStart:
+        await bridge.setTileViewerCaptureFrameStart();
+      case TileCaptureMode.vblankStart:
+        await bridge.setTileViewerCaptureVblankStart();
+      case TileCaptureMode.scanline:
+        await bridge.setTileViewerCaptureScanline(
+          scanline: _scanline,
+          dot: _dot,
+        );
     }
   }
 
-  @override
-  bool shouldRepaint(covariant _TileHighlightPainter oldDelegate) =>
-      hoveredTile != oldDelegate.hoveredTile ||
-      selectedTile != oldDelegate.selectedTile;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Tile Preview and Info Widgets (matching TilemapViewer style)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// CHR tile preview showing zoomed 8×8 tile with palette colors
-class _ChrTilePreview extends StatelessWidget {
-  const _ChrTilePreview({required this.snapshot, required this.info});
-
-  final bridge.TileSnapshot snapshot;
-  final _TileInfo info;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          width: 64,
-          height: 64,
-          decoration: BoxDecoration(
-            border: Border.all(
-              color: Theme.of(context).colorScheme.outlineVariant,
-            ),
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: CustomPaint(
-            painter: _ChrTilePreviewPainter(snapshot: snapshot, info: info),
-          ),
-        ),
-        const SizedBox(height: 8),
-        _PaletteStrip(snapshot: snapshot),
-      ],
+  void _setCaptureMode(TileCaptureMode value) {
+    setState(() => _captureMode = value);
+    unawaitedLogged(
+      _applyCaptureMode(),
+      message: 'Failed to set CHR capture point',
     );
   }
-}
 
-class _ChrTilePreviewPainter extends CustomPainter {
-  _ChrTilePreviewPainter({required this.snapshot, required this.info});
+  void _submitScanline(String value) {
+    final parsed = int.tryParse(value);
+    if (parsed == null || parsed < _minScanline || parsed > _maxScanline) {
+      return;
+    }
+    setState(() => _scanline = parsed);
+    _scanlineController.text = _scanline.toString();
+    unawaitedLogged(
+      _applyCaptureMode(),
+      message: 'Failed to set CHR capture point',
+    );
+  }
 
-  final bridge.TileSnapshot snapshot;
-  final _TileInfo info;
+  void _submitDot(String value) {
+    final parsed = int.tryParse(value);
+    if (parsed == null || parsed < _minDot || parsed > _maxDot) return;
+    setState(() => _dot = parsed);
+    _dotController.text = _dot.toString();
+    unawaitedLogged(
+      _applyCaptureMode(),
+      message: 'Failed to set CHR capture point',
+    );
+  }
 
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint();
-    final paletteIndex = snapshot.selectedPalette.clamp(0, 7);
-    final palBase = paletteIndex < 4
-        ? paletteIndex * 4
-        : 0x10 + (paletteIndex - 4) * 4;
+  void _setPreset(TilePreset preset) {
+    unawaitedLogged(
+      _applyPreset(preset),
+      message: 'Failed to apply tile viewer preset',
+    );
+  }
 
-    // Draw 2x2 grid showing the 4 palette colors as a placeholder
-    final cellW = size.width / 2;
-    final cellH = size.height / 2;
+  Future<void> _applyPreset(TilePreset preset) async {
+    final snapshot = _tileSnapshot;
+    late final TileSource newSource;
+    late final int newAddress;
+    late final int newColumns;
+    late final int newRows;
+    late final TileLayout newLayout;
+    int? newPalette;
 
-    for (var i = 0; i < 4; i++) {
-      final pal = snapshot.palette;
-      final idx = i == 0 ? 0 : palBase + i;
-      final nesColor = (idx < pal.length ? pal[idx] : 0) & 0x3F;
-      paint.color = _colorFromNes(nesColor);
-
-      final x = (i % 2) * cellW;
-      final y = (i ~/ 2) * cellH;
-      canvas.drawRect(Rect.fromLTWH(x, y, cellW, cellH), paint);
+    switch (preset) {
+      case TilePreset.ppu:
+        newSource = TileSource.ppu;
+        newAddress = 0;
+        newColumns = 16;
+        newRows = 32;
+        newLayout = TileLayout.normal;
+        newPalette = null;
+      case TilePreset.chr:
+        newSource = TileSource.chrRom;
+        newAddress = 0;
+        newColumns = 16;
+        newRows = 32;
+        newLayout = TileLayout.normal;
+        newPalette = null;
+      case TilePreset.rom:
+        newSource = TileSource.prgRom;
+        newAddress = 0;
+        newColumns = 16;
+        newRows = 32;
+        newLayout = TileLayout.normal;
+        newPalette = null;
+      case TilePreset.bg:
+        newSource = TileSource.ppu;
+        newAddress = snapshot?.bgPatternBase ?? 0;
+        newColumns = 16;
+        newRows = 16;
+        newLayout = TileLayout.normal;
+        newPalette = _selectedPalette >= 4 ? 0 : _selectedPalette;
+      case TilePreset.oam:
+        newSource = TileSource.ppu;
+        final largeSprites = snapshot?.largeSprites ?? false;
+        if (largeSprites) {
+          newAddress = 0;
+          newColumns = 16;
+          newRows = 32;
+          newLayout = TileLayout.singleLine8x16;
+        } else {
+          newAddress = snapshot?.spritePatternBase ?? 0;
+          newColumns = 16;
+          newRows = 16;
+          newLayout = TileLayout.normal;
+        }
+        newPalette = _selectedPalette < 4 ? 4 : _selectedPalette;
     }
 
-    // Draw tile index in center
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text:
-            '\$${info.tileIndexInTable.toRadixString(16).toUpperCase().padLeft(2, '0')}',
-        style: TextStyle(
-          color: Colors.white,
-          fontSize: size.width / 4,
-          fontFamily: 'monospace',
-          fontWeight: FontWeight.bold,
-          shadows: const [Shadow(blurRadius: 2, color: Colors.black)],
-        ),
-      ),
-      textDirection: TextDirection.ltr,
-    )..layout();
-    textPainter.paint(
-      canvas,
-      Offset(
-        (size.width - textPainter.width) / 2,
-        (size.height - textPainter.height) / 2,
-      ),
-    );
-  }
+    final needsTextureRecreate =
+        newColumns != _columnCount || newRows != _rowCount;
 
-  Color _colorFromNes(int nesColor) {
-    final rgba = snapshot.rgbaPalette;
-    final base = (nesColor & 0x3F) * 4;
-    if (base + 3 >= rgba.length) return Colors.black;
-    return Color.fromARGB(
-      rgba[base + 3],
-      rgba[base],
-      rgba[base + 1],
-      rgba[base + 2],
-    );
-  }
+    setState(() {
+      _selectedPreset = preset;
+      _source = newSource;
+      _startAddress = newAddress;
+      _columnCount = newColumns;
+      _rowCount = newRows;
+      _layout = newLayout;
+      if (newPalette != null) {
+        _selectedPalette = newPalette;
+      }
+    });
 
-  @override
-  bool shouldRepaint(covariant _ChrTilePreviewPainter old) =>
-      info.tileIndex != old.info.tileIndex ||
-      snapshot.selectedPalette != old.snapshot.selectedPalette;
-}
-
-/// Shows the 4 colors of the selected palette
-class _PaletteStrip extends StatelessWidget {
-  const _PaletteStrip({required this.snapshot});
-
-  final bridge.TileSnapshot snapshot;
-
-  @override
-  Widget build(BuildContext context) {
-    final paletteIndex = snapshot.selectedPalette.clamp(0, 7);
-    final palBase = paletteIndex < 4
-        ? paletteIndex * 4
-        : 0x10 + (paletteIndex - 4) * 4;
-
-    return Row(
-      children: List.generate(4, (i) {
-        final pal = snapshot.palette;
-        final idx = palBase + i;
-        final nesColor =
-            (i == 0
-                ? (pal.isNotEmpty ? pal[0] : 0)
-                : (idx < pal.length ? pal[idx] : 0)) &
-            0x3F;
-        final rgba = snapshot.rgbaPalette;
-        final base = nesColor * 4;
-        final color = base + 3 < rgba.length
-            ? Color.fromARGB(
-                rgba[base + 3],
-                rgba[base],
-                rgba[base + 1],
-                rgba[base + 2],
-              )
-            : Colors.black;
-
-        return Container(width: 16, height: 8, color: color);
-      }),
-    );
-  }
-}
-
-/// Table showing tile metadata
-class _TileInfoTable extends StatelessWidget {
-  const _TileInfoTable({required this.context, required this.info});
-
-  final BuildContext context;
-  final _TileInfo info;
-
-  @override
-  Widget build(BuildContext ctx) {
-    final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-    final labelStyle = theme.textTheme.bodySmall?.copyWith(
-      color: theme.colorScheme.onSurfaceVariant,
-    );
-    final valueStyle = theme.textTheme.bodySmall?.copyWith(
-      fontWeight: FontWeight.w600,
-      fontFamily: 'monospace',
-    );
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _kv(
-          l10n.tileViewerPatternTable,
-          '${info.patternTable}',
-          labelStyle,
-          valueStyle,
-        ),
-        _kv(
-          l10n.tileViewerTileIndex,
-          '\$${info.tileIndexInTable.toRadixString(16).toUpperCase().padLeft(2, '0')}',
-          labelStyle,
-          valueStyle,
-        ),
-        _kv(
-          l10n.tileViewerChrAddress,
-          '\$${info.chrAddress.toRadixString(16).toUpperCase().padLeft(4, '0')}',
-          labelStyle,
-          valueStyle,
-        ),
-      ],
-    );
-  }
-
-  Widget _kv(
-    String label,
-    String value,
-    TextStyle? labelStyle,
-    TextStyle? valueStyle,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 3),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(label, style: labelStyle),
-          Text(value, style: valueStyle),
-        ],
-      ),
-    );
-  }
-}
-
-/// Hex address input with 4-button navigation (Mesen2 style)
-/// Buttons: << (prev page), < (prev byte), [value], > (next byte), >> (next page)
-class _AddressInput extends StatelessWidget {
-  const _AddressInput({
-    required this.value,
-    required this.maxValue,
-    required this.pageIncrement,
-    required this.onChanged,
-    this.byteIncrement = 1,
-  });
-
-  final int value;
-  final int maxValue;
-  final int pageIncrement; // Large step (page)
-  final int byteIncrement; // Small step (byte/tile)
-  final ValueChanged<int> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final hexValue =
-        '\$${value.toRadixString(16).toUpperCase().padLeft(4, '0')}';
-
-    Widget navButton(String label, int delta, {bool enabled = true}) {
-      return InkWell(
-        onTap: enabled
-            ? () => onChanged((value + delta).clamp(0, maxValue))
-            : null,
-        borderRadius: BorderRadius.circular(4),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-          child: Text(
-            label,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontFamily: 'monospace',
-              fontWeight: FontWeight.bold,
-              color: enabled
-                  ? theme.colorScheme.primary
-                  : theme.colorScheme.onSurface.withValues(alpha: 0.3),
-            ),
-          ),
-        ),
-      );
+    await bridge.setTileViewerSource(source: newSource.index);
+    await bridge.setTileViewerStartAddress(startAddress: newAddress);
+    await bridge.setTileViewerSize(columns: newColumns, rows: newRows);
+    await bridge.setTileViewerLayout(layout: newLayout.index);
+    if (newPalette != null) {
+      await bridge.setTileViewerPalette(paletteIndex: newPalette);
     }
 
-    return Row(
-      children: [
-        navButton('«', -pageIncrement, enabled: value > 0),
-        navButton('<', -byteIncrement, enabled: value > 0),
-        Expanded(
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.outlineVariant),
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              hexValue,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontFamily: 'monospace',
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ),
-        // Next byte > (Mesen2: CanIncrementSmall = Value < Maximum)
-        navButton('>', byteIncrement, enabled: value < maxValue),
-        // Next page >> (Mesen2: CanIncrementLarge = Value < Maximum - LargeIncrement + 1)
-        navButton(
-          '»',
-          pageIncrement,
-          enabled: value < maxValue - pageIncrement + 1,
-        ),
-      ],
+    if (needsTextureRecreate) {
+      await _recreateTexture();
+    }
+  }
+
+  void _clearPresetSelection() {
+    if (_selectedPreset != null) {
+      setState(() => _selectedPreset = null);
+    }
+  }
+
+  void _setSource(TileSource value) {
+    setState(() => _source = value);
+    unawaitedLogged(
+      bridge.setTileViewerSource(source: value.index),
+      message: 'Failed to set tile viewer source',
     );
   }
-}
 
-/// Compact numeric input with label for size controls
-class _SizeInput extends StatelessWidget {
-  const _SizeInput({
-    required this.label,
-    required this.value,
-    required this.min,
-    required this.max,
-    required this.step,
-    required this.onChanged,
-  });
+  void _setStartAddress(int value) {
+    setState(() => _startAddress = value);
+    unawaitedLogged(
+      bridge.setTileViewerStartAddress(startAddress: value),
+      message: 'Failed to set tile viewer start address',
+    );
+  }
 
-  final String label;
-  final int value;
-  final int min;
-  final int max;
-  final int step;
-  final ValueChanged<int> onChanged;
+  void _setLayout(TileLayout value) {
+    setState(() => _layout = value);
+    unawaitedLogged(
+      bridge.setTileViewerLayout(layout: value.index),
+      message: 'Failed to set tile viewer layout',
+    );
+  }
 
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+  void _setBackground(TileBackground value) {
+    setState(() => _background = value);
+    unawaitedLogged(
+      bridge.setTileViewerBackground(background: value.index),
+      message: 'Failed to set tile viewer background',
+    );
+  }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          label,
-          style: theme.textTheme.labelSmall?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-        ),
-        const SizedBox(height: 4),
-        Row(
-          children: [
-            InkWell(
-              onTap: value > min
-                  ? () => onChanged((value - step).clamp(min, max))
-                  : null,
-              borderRadius: BorderRadius.circular(4),
-              child: Container(
-                padding: const EdgeInsets.all(4),
-                child: Icon(
-                  Icons.remove,
-                  size: 16,
-                  color: value > min
-                      ? theme.colorScheme.onSurface
-                      : theme.colorScheme.onSurface.withValues(alpha: 0.3),
-                ),
-              ),
-            ),
-            Expanded(
-              child: Text(
-                '$value',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-            InkWell(
-              onTap: value < max
-                  ? () => onChanged((value + step).clamp(min, max))
-                  : null,
-              borderRadius: BorderRadius.circular(4),
-              child: Container(
-                padding: const EdgeInsets.all(4),
-                child: Icon(
-                  Icons.add,
-                  size: 16,
-                  color: value < max
-                      ? theme.colorScheme.onSurface
-                      : theme.colorScheme.onSurface.withValues(alpha: 0.3),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ],
+  void _setUseGrayscale(bool enabled) {
+    setState(() => _useGrayscale = enabled);
+    unawaitedLogged(
+      bridge.setTileViewerDisplayMode(mode: enabled ? 1 : 0),
+      message: 'Failed to set tile viewer display mode',
+    );
+  }
+
+  void _setPalette(int value) {
+    setState(() => _selectedPalette = value);
+    _clearPresetSelection();
+    unawaitedLogged(
+      bridge.setTileViewerPalette(paletteIndex: value),
+      message: 'Failed to set tile viewer palette',
     );
   }
 }


### PR DESCRIPTION
## Summary
- split the large tile viewer into focused model, geometry, painter, canvas, settings, side panel, control, and tile info widget files
- keep texture lifecycle, backend bridge calls, and state orchestration in tile_viewer.dart
- avoid Dart part files

## Verification
- dart format apps/nesium_flutter/lib/features/debugger/tile_viewer.dart apps/nesium_flutter/lib/features/debugger/tile
- flutter analyze
- git diff --check -- apps/nesium_flutter/lib/features/debugger/tile_viewer.dart apps/nesium_flutter/lib/features/debugger/tile